### PR TITLE
remove resourceID

### DIFF
--- a/pkg/domain/cloud.go
+++ b/pkg/domain/cloud.go
@@ -11,7 +11,6 @@ type CloudAssetChanges struct {
 	ResourceType string
 	AccountID    string
 	Region       string
-	ResourceID   string
 	ARN          string
 	Tags         map[string]string
 }
@@ -32,6 +31,6 @@ type CloudAssetDetails struct {
 	ResourceType       string
 	AccountID          string
 	Region             string
-	ResourceID         string
+	ARN                string
 	Tags               map[string]string
 }

--- a/pkg/handlers/v1/cloud_fetch.go
+++ b/pkg/handlers/v1/cloud_fetch.go
@@ -22,7 +22,7 @@ type CloudAssetDetails struct {
 	ResourceType       string            `json:"resourceType"`
 	AccountID          string            `json:"accountId"`
 	Region             string            `json:"region"`
-	ResourceID         string            `json:"resourceId"`
+	ARN                string            `json:"arn"`
 	Tags               map[string]string `json:"tags"`
 }
 
@@ -137,7 +137,7 @@ func extractOutput(assets []domain.CloudAssetDetails) CloudAssets {
 			ResourceType:       asset.ResourceType,
 			AccountID:          asset.AccountID,
 			Region:             asset.Region,
-			ResourceID:         asset.ResourceID,
+			ARN:                asset.ARN,
 			Tags:               tags,
 		}
 	}

--- a/pkg/handlers/v1/cloud_fetch_test.go
+++ b/pkg/handlers/v1/cloud_fetch_test.go
@@ -222,7 +222,7 @@ func TestExtractOutput(t *testing.T) {
 					ResourceType: "resourceType",
 					AccountID:    "accountId",
 					Region:       "Region",
-					ResourceID:   "resourceID",
+					ARN:          "arn",
 				},
 			},
 			expected: CloudAssets{
@@ -234,7 +234,7 @@ func TestExtractOutput(t *testing.T) {
 						ResourceType:       "resourceType",
 						AccountID:          "accountId",
 						Region:             "Region",
-						ResourceID:         "resourceID",
+						ARN:                "arn",
 						Tags:               make(map[string]string),
 					},
 				},

--- a/pkg/handlers/v1/cloud_insert.go
+++ b/pkg/handlers/v1/cloud_insert.go
@@ -15,7 +15,6 @@ type CloudAssetChanges struct {
 	ResourceType string            `json:"resourceType"`
 	AccountID    string            `json:"accountId"`
 	Region       string            `json:"region"`
-	ResourceID   string            `json:"resourceId"`
 	ARN          string            `json:"arn"`
 	Tags         map[string]string `json:"tags"`
 }
@@ -49,7 +48,6 @@ func (h *CloudInsertHandler) Handle(ctx context.Context, input CloudAssetChanges
 		ResourceType: input.ResourceType,
 		AccountID:    input.AccountID,
 		Region:       input.Region,
-		ResourceID:   input.ResourceID,
 		ARN:          input.ARN,
 		Tags:         input.Tags,
 		Changes:      make([]domain.NetworkChanges, 0, len(input.Changes)),

--- a/pkg/handlers/v1/cloud_insert_test.go
+++ b/pkg/handlers/v1/cloud_insert_test.go
@@ -27,7 +27,7 @@ func newInsertHandler(storer domain.CloudAssetStorer) *CloudInsertHandler {
 func validInsertInput() CloudAssetChanges {
 	return CloudAssetChanges{
 		ChangeTime:   time.Now().Format(time.RFC3339Nano),
-		ResourceID:   "cloud-resource-id",
+		ARN:          "cloud-resource-arn",
 		ResourceType: "cloud-resource-type",
 		Region:       "cloud-region",
 		AccountID:    "cloud-account-id",

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -282,7 +282,7 @@ func (db *DB) runQuery(ctx context.Context, query string, args ...interface{}) (
 		var isJoin bool      // no need for sql.NullBool as the DB column is guaranteed a value
 		var timestamp time.Time
 
-		err = rows.Scan(&row.ResourceID, &ipAddress, &hostname, &isPublic, &isJoin, &timestamp, &row.AccountID, &row.Region, &row.ResourceType, &metaBytes)
+		err = rows.Scan(&row.ARN, &ipAddress, &hostname, &isPublic, &isJoin, &timestamp, &row.AccountID, &row.Region, &row.ResourceType, &metaBytes)
 
 		if err == nil {
 			if metaBytes != nil {
@@ -290,27 +290,27 @@ func (db *DB) runQuery(ctx context.Context, query string, args ...interface{}) (
 				_ = json.Unmarshal(metaBytes, &i) // we already checked for nil, and the DB column is JSONB; no need for err check here
 				row.Tags = i
 			}
-			if tempMap[row.ResourceID] == nil {
-				tempMap[row.ResourceID] = &row
+			if tempMap[row.ARN] == nil {
+				tempMap[row.ARN] = &row
 			}
 			found := false
 			if hostname.Valid {
-				for _, val := range tempMap[row.ResourceID].Hostnames {
+				for _, val := range tempMap[row.ARN].Hostnames {
 					if strings.EqualFold(val, hostname.String) {
 						found = true
 						break
 					}
 				}
 				if !found {
-					tempMap[row.ResourceID].Hostnames = append(tempMap[row.ResourceID].Hostnames, hostname.String)
+					tempMap[row.ARN].Hostnames = append(tempMap[row.ARN].Hostnames, hostname.String)
 				}
 			}
 			found = false
 			var ipAddresses *[]string
 			if isPublic {
-				ipAddresses = &tempMap[row.ResourceID].PublicIPAddresses
+				ipAddresses = &tempMap[row.ARN].PublicIPAddresses
 			} else {
-				ipAddresses = &tempMap[row.ResourceID].PrivateIPAddresses
+				ipAddresses = &tempMap[row.ARN].PrivateIPAddresses
 			}
 			for _, val := range *ipAddresses {
 				if strings.EqualFold(val, ipAddress) {
@@ -321,9 +321,9 @@ func (db *DB) runQuery(ctx context.Context, query string, args ...interface{}) (
 			if !found {
 				newArray := append(*ipAddresses, ipAddress)
 				if isPublic {
-					tempMap[row.ResourceID].PublicIPAddresses = newArray
+					tempMap[row.ARN].PublicIPAddresses = newArray
 				} else {
-					tempMap[row.ResourceID].PrivateIPAddresses = newArray
+					tempMap[row.ARN].PrivateIPAddresses = newArray
 				}
 			}
 		}

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -275,7 +275,7 @@ func fakeCloudAssetChanges() domain.CloudAssetChanges {
 	hostnames := []string{"google.com"}
 	networkChangesArray := []domain.NetworkChanges{domain.NetworkChanges{privateIPs, publicIPs, hostnames, "ADDED"}}
 	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
-	cloudAssetChanges := domain.CloudAssetChanges{networkChangesArray, timestamp, "rtype", "aid", "region", "rid", "arn", map[string]string{"tag1": "val1"}}
+	cloudAssetChanges := domain.CloudAssetChanges{networkChangesArray, timestamp, "rtype", "aid", "region", "arn", map[string]string{"tag1": "val1"}}
 	return cloudAssetChanges
 }
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -76,7 +76,7 @@ func TestGetStatusByHostnameAtTimestamp1(t *testing.T) {
 	hostnames := []string{"yahoo.com"} // nolint
 	timestamp, _ := time.Parse(time.RFC3339, "2019-08-09T08:29:35+00:00")
 
-	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -109,7 +109,7 @@ func TestGetStatusByHostnameAtTimestamp2(t *testing.T) {
 	hostnames := []string{"yahoo.com"}   // nolint
 	timestamp, _ := time.Parse(time.RFC3339, "2019-08-09T08:29:35+00:00")
 
-	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -149,7 +149,7 @@ func TestGetStatusByHostnameAtTimestamp3(t *testing.T) {
 	hostnames := []string{"yahoo.com"}   // nolint
 	timestamp, _ := time.Parse(time.RFC3339, "2019-08-09T08:29:35+00:00")
 
-	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -157,7 +157,7 @@ func TestGetStatusByHostnameAtTimestamp3(t *testing.T) {
 	timestamp2, _ := time.Parse(time.RFC3339, "2019-08-11T08:29:35+00:00") // August 11
 	privateIPs2 := []string{"4.3.2.1"}
 	publicIPs2 := []string{"8.7.6.5"}
-	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs2, publicIPs2, hostnames, timestamp2, `arn2`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs2, publicIPs2, hostnames, timestamp2, `arn2`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange2); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -190,7 +190,7 @@ func TestGetStatusByHostnameAtTimestamp4(t *testing.T) {
 	hostnames := []string{"yahoo.com"}   // nolint
 	timestamp, _ := time.Parse(time.RFC3339, "2019-08-09T08:29:35+00:00")
 
-	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -198,7 +198,7 @@ func TestGetStatusByHostnameAtTimestamp4(t *testing.T) {
 	timestamp2, _ := time.Parse(time.RFC3339, "2019-08-12T08:29:35+00:00") // August 12
 	privateIPs2 := []string{"4.3.2.1"}
 	publicIPs2 := []string{"8.7.6.5"}
-	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs2, publicIPs2, hostnames, timestamp2, `arn2`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs2, publicIPs2, hostnames, timestamp2, `arn2`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange2); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -230,7 +230,7 @@ func TestGetStatusByIPAddressAtTimestamp1(t *testing.T) {
 	hostnames := []string{"yahoo.com"}   // nolint
 	timestamp, _ := time.Parse(time.RFC3339, "2019-08-09T08:29:35+00:00")
 
-	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -263,7 +263,7 @@ func TestGetStatusByIPAddressAtTimestamp2(t *testing.T) {
 	hostnames := []string{"yahoo.com"} // nolint
 	timestamp, _ := time.Parse(time.RFC3339, "2019-08-09T08:29:35+00:00")
 
-	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -303,14 +303,14 @@ func TestGetStatusByIPAddressAtTimestamp3(t *testing.T) {
 	hostnames := []string{"yahoo.com"} // nolint
 	timestamp, _ := time.Parse(time.RFC3339, "2019-08-09T08:29:35+00:00")
 
-	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange); err != nil {
 		t.Fatal(err.Error())
 	}
 
 	timestamp2, _ := time.Parse(time.RFC3339, "2019-08-11T08:29:35+00:00") // August 11
 	hostnames2 := []string{"blarg.com"}
-	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames2, timestamp2, `arn2`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames2, timestamp2, `arn2`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange2); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -343,14 +343,14 @@ func TestGetStatusByIPAddressAtTimestamp4(t *testing.T) {
 	hostnames := []string{"yahoo.com"} // nolint
 	timestamp, _ := time.Parse(time.RFC3339, "2019-08-09T08:29:35+00:00")
 
-	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange); err != nil {
 		t.Fatal(err.Error())
 	}
 
 	timestamp2, _ := time.Parse(time.RFC3339, "2019-08-12T08:29:35+00:00") // August 12
 	hostnames2 := []string{"blarg.com"}
-	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames2, timestamp2, `arn2`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames2, timestamp2, `arn2`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange2); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -383,27 +383,27 @@ func TestGetStatusByIPAddressAtTimestamp5(t *testing.T) {
 	hostnames := []string{"yahoo.com"} // nolint
 	timestamp, _ := time.Parse(time.RFC3339, "2019-08-09T08:29:35+00:00")
 
-	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames, timestamp, `arn`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange); err != nil {
 		t.Fatal(err.Error())
 	}
 
 	timestamp2, _ := time.Parse(time.RFC3339, "2019-08-12T08:29:35+00:00") // August 12
 	hostnames2 := []string{"blarg.com"}
-	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames2, timestamp2, `arn2`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange2 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames2, timestamp2, `arn2`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange2); err != nil {
 		t.Fatal(err.Error())
 	}
 
 	timestamp3, _ := time.Parse(time.RFC3339, "2019-08-10T08:29:35+00:00") // August 10, arn3
 	hostnames3 := []string{"reddit.com"}
-	fakeCloudAssetChange3 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames3, timestamp3, `arn3`, `rid`, `rtype`, `aid`, `region`, nil, true)
+	fakeCloudAssetChange3 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames3, timestamp3, `arn3`, `rtype`, `aid`, `region`, nil, true)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange3); err != nil {
 		t.Fatal(err.Error())
 	}
 
 	timestamp4, _ := time.Parse(time.RFC3339, "2019-08-10T08:39:35+00:00") // August 10, 10 minutes later, arn3 drops the same IP address
-	fakeCloudAssetChange4 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames3, timestamp4, `arn3`, `rid`, `rtype`, `aid`, `region`, nil, false)
+	fakeCloudAssetChange4 := newFakeCloudAssetChange(privateIPs, publicIPs, hostnames3, timestamp4, `arn3`, `rtype`, `aid`, `region`, nil, false)
 	if err := dbStorage.Store(ctx, fakeCloudAssetChange4); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -472,7 +472,7 @@ func dropTables(db *sql.DB) error {
 	sqlFile := "1_clean.sql"
 
 	box := packr.New("box", "../scripts")
-	path, err := box.Find(sqlFile)
+	_, err := box.Find(sqlFile)
 	if err != nil {
 		return err
 	}
@@ -480,8 +480,6 @@ func dropTables(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-
-	fmt.Printf("DROPping existing aws_* tables %s\n", string(path))
 
 	if _, err = db.Exec(s); err != nil {
 		return err
@@ -496,7 +494,7 @@ func createTables(db *sql.DB) error {
 	sqlFile := "2_create.sql"
 
 	box := packr.New("box", "../scripts")
-	path, err := box.Find(sqlFile)
+	_, err := box.Find(sqlFile)
 	if err != nil {
 		return err
 	}
@@ -504,8 +502,6 @@ func createTables(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-
-	fmt.Printf("CREATEing aws_* tables using %s\n", string(path))
 
 	if _, err = db.Exec(s); err != nil {
 		return err
@@ -516,13 +512,13 @@ func createTables(db *sql.DB) error {
 }
 
 // newFakeCloudAssetChange is a utility function to create the struct that is the inbound change report we need to save
-func newFakeCloudAssetChange(privateIPs []string, publicIPs []string, hostnames []string, timestamp time.Time, arn string, resourceID string, resourceType string, accountID string, region string, tags map[string]string, added bool) domain.CloudAssetChanges { // nolint
+func newFakeCloudAssetChange(privateIPs []string, publicIPs []string, hostnames []string, timestamp time.Time, arn string, resourceType string, accountID string, region string, tags map[string]string, added bool) domain.CloudAssetChanges { // nolint
 	eventType := "ADDED"
 	if !added {
 		eventType = "DELETED"
 	}
 	networkChangesArray := []domain.NetworkChanges{domain.NetworkChanges{privateIPs, publicIPs, hostnames, eventType}}
-	cloudAssetChanges := domain.CloudAssetChanges{networkChangesArray, timestamp, resourceType, accountID, region, resourceID, arn, tags}
+	cloudAssetChanges := domain.CloudAssetChanges{networkChangesArray, timestamp, resourceType, accountID, region, arn, tags}
 
 	return cloudAssetChanges
 }


### PR DESCRIPTION
We no longer rely on the AWS resourceID as the unique identifier. We now use ARN which has the resource ID as well as additional identifying information