### PR TITLE
add get handler for partitions

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -265,6 +265,29 @@ paths:
               #! end !#
               "bodyPassthrough": true
             }
+    get:
+      summary: "Get all partitions"
+      description: "This is an endpoint to view all active partitions."
+      responses:
+        200:
+          description: "Active partitions"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Partitions'
+      x-transportd:
+        backend: app
+        enabled:
+          - "metrics"
+          - "accesslog"
+          - "requestvalidation"
+          - "responsevalidation"
+          - "lambda"
+        lambda:
+          arn: "getPartitions"
+          async: false
+          success: '{"status": 200, "bodyPassthrough": true}'
+          error: '{"status": 500, "bodyPassthrough": true}'
 components:
   schemas:
     CloudAssetChanges:
@@ -350,6 +373,27 @@ components:
           type: object
           additionalProperties:
             type: string
+    Partitions:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/Partition"
+    Partition:
+      type: object
+      properties:
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        begin:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
     Error:
       type: object
       properties:

--- a/main.go
+++ b/main.go
@@ -42,11 +42,16 @@ func main() {
 		LogFn:     domain.LoggerFromContext,
 		Generator: dbStorage,
 	}
+	getPartitions := &v1.GetPartitionsHandler{
+		LogFn:  domain.LoggerFromContext,
+		Getter: dbStorage,
+	}
 	handlers := map[string]serverfull.Function{
 		"insert":          serverfull.NewFunction(insert.Handle),
 		"fetchByIP":       serverfull.NewFunction(fetchByIP.Handle),
 		"fetchByHostname": serverfull.NewFunction(fetchByHostname.Handle),
 		"createPartition": serverfull.NewFunction(createPartition.Handle),
+		"getPartitions":   serverfull.NewFunction(getPartitions),
 	}
 
 	fetcher := &serverfull.StaticFetcher{Functions: handlers}

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 		"fetchByIP":       serverfull.NewFunction(fetchByIP.Handle),
 		"fetchByHostname": serverfull.NewFunction(fetchByHostname.Handle),
 		"createPartition": serverfull.NewFunction(createPartition.Handle),
-		"getPartitions":   serverfull.NewFunction(getPartitions),
+		"getPartitions":   serverfull.NewFunction(getPartitions.Handle),
 	}
 
 	fetcher := &serverfull.StaticFetcher{Functions: handlers}

--- a/pkg/domain/storage.go
+++ b/pkg/domain/storage.go
@@ -12,6 +12,11 @@ type PartitionGenerator interface {
 	GeneratePartitionWithTimestamp(context.Context, time.Time) error
 }
 
+// PartitionsGetter is used to fetch a list of partitions
+type PartitionsGetter interface {
+	GetPartitions(context.Context) ([]Partition, error)
+}
+
 // CloudAssetStorer interface provides functions for inserting cloud assets
 type CloudAssetStorer interface {
 	Store(context.Context, CloudAssetChanges) error
@@ -27,11 +32,19 @@ type CloudAssetByHostnameFetcher interface {
 	FetchByHostname(ctx context.Context, when time.Time, hostname string) ([]CloudAssetDetails, error)
 }
 
+// Partition represents a database partition with the specified time range
+type Partition struct {
+	Name      string
+	CreatedAt time.Time
+	Begin     time.Time
+	End       time.Time
+}
+
 // PartitionConflict is used to indicate a partition exists which overlaps with a partition requested to be created
 type PartitionConflict struct {
 	Name string
 }
 
 func (e PartitionConflict) Error() string {
-	return fmt.Sprintf("A partition already exists which overlaps witht the requested partition, %s", e.Name)
+	return fmt.Sprintf("A partition already exists which overlaps with the requested partition, %s", e.Name)
 }

--- a/pkg/handlers/v1/get_partitions.go
+++ b/pkg/handlers/v1/get_partitions.go
@@ -1,0 +1,49 @@
+package v1
+
+import (
+	"context"
+	"time"
+
+	"github.com/asecurityteam/asset-inventory-api/pkg/domain"
+	"github.com/asecurityteam/asset-inventory-api/pkg/logs"
+)
+
+// GetPartitionsOutput returns the list of current partitions
+type GetPartitionsOutput struct {
+	Results []Partition `json:"results"`
+}
+
+// Partition represents a created database partition
+type Partition struct {
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"createdAt"`
+	Begin     time.Time `json:"begin"`
+	End       time.Time `json:"end"`
+}
+
+// GetPartitionsHandler handles requests for getting the time based partitions
+type GetPartitionsHandler struct {
+	LogFn  domain.LogFn
+	Getter domain.PartitionsGetter
+}
+
+// Handle handles the partition creation request
+func (h *GetPartitionsHandler) Handle(ctx context.Context) (GetPartitionsOutput, error) {
+	partitions, err := h.Getter.GetPartitions(ctx)
+	if err != nil {
+		h.LogFn(ctx).Error(logs.StorageError{Reason: err.Error()})
+		return GetPartitionsOutput{}, err
+	}
+	results := make([]Partition, 0, len(partitions))
+	for _, partition := range partitions {
+		results = append(results, Partition{
+			Name:      partition.Name,
+			CreatedAt: partition.CreatedAt,
+			Begin:     partition.Begin,
+			End:       partition.End,
+		})
+	}
+	return GetPartitionsOutput{
+		Results: results,
+	}, nil
+}

--- a/pkg/handlers/v1/get_partitions_test.go
+++ b/pkg/handlers/v1/get_partitions_test.go
@@ -1,0 +1,56 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/asecurityteam/asset-inventory-api/pkg/domain"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPartitionsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGetter := NewMockPartitionsGetter(ctrl)
+	mockGetter.EXPECT().GetPartitions(gomock.Any()).Return(nil, errors.New(""))
+
+	handler := GetPartitionsHandler{
+		LogFn:  testLogFn,
+		Getter: mockGetter,
+	}
+
+	_, err := handler.Handle(context.Background())
+	assert.Error(t, err)
+}
+
+func TestGetPartitions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	partitions := []domain.Partition{
+		{
+			Name: "partitionA",
+		},
+		{
+			Name: "partitionB",
+		},
+		{
+			Name: "partitionC",
+		},
+	}
+
+	mockGetter := NewMockPartitionsGetter(ctrl)
+	mockGetter.EXPECT().GetPartitions(gomock.Any()).Return(partitions, nil)
+
+	handler := GetPartitionsHandler{
+		LogFn:  testLogFn,
+		Getter: mockGetter,
+	}
+
+	results, err := handler.Handle(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, len(partitions), len(results.Results))
+}

--- a/pkg/handlers/v1/mock_storage_test.go
+++ b/pkg/handlers/v1/mock_storage_test.go
@@ -51,6 +51,38 @@ func (_mr *_MockPartitionGeneratorRecorder) GeneratePartitionWithTimestamp(arg0,
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GeneratePartitionWithTimestamp", arg0, arg1)
 }
 
+// Mock of PartitionsGetter interface
+type MockPartitionsGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockPartitionsGetterRecorder
+}
+
+// Recorder for MockPartitionsGetter (not exported)
+type _MockPartitionsGetterRecorder struct {
+	mock *MockPartitionsGetter
+}
+
+func NewMockPartitionsGetter(ctrl *gomock.Controller) *MockPartitionsGetter {
+	mock := &MockPartitionsGetter{ctrl: ctrl}
+	mock.recorder = &_MockPartitionsGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockPartitionsGetter) EXPECT() *_MockPartitionsGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockPartitionsGetter) GetPartitions(_param0 context.Context) ([]domain.Partition, error) {
+	ret := _m.ctrl.Call(_m, "GetPartitions", _param0)
+	ret0, _ := ret[0].([]domain.Partition)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockPartitionsGetterRecorder) GetPartitions(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPartitions", arg0)
+}
+
 // Mock of CloudAssetStorer interface
 type MockCloudAssetStorer struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Currently, there is a mechanism by which we can create partitions in out PG database. For operational purposes, in testing and operating this feature, it would be useful to be able to view all current partitions in the DB.

This PR creates a new handler in the OSS project to fetch new partitions and an api.yaml entry which registers the new handler.