### PR TITLE
pass partition duration as a parameter

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -213,14 +213,12 @@ paths:
     post:
       summary: "Create a new partition"
       description: "This is an endpoint to administer changes to the partitions in the postgres database. Calling without a timestamp will create the next time based partition in the sequence. Calling with a timestamp will create a new partition for that timestamp."
-      parameters:
-        - name: "timestamp"
-          in: "query"
-          description: "Optional time for the partition"
-          required: false
-          schema:
-            type: "string"
-            format: "date-time"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePartitionInput'
       responses:
         204:
           description: "Partition created"
@@ -247,12 +245,7 @@ paths:
         lambda:
           arn: "createPartition"
           async: false
-          request: >
-            {
-              #!if .Request.Query.timestamp!#
-              "timestamp":"#!index .Request.Query.timestamp 0!#",
-              #!end!#
-            }
+          request: '#! json .Request.Body !#'
           success: '{"status": 204, "bodyPassthrough": true}'
           error: >
             {
@@ -394,6 +387,14 @@ components:
         end:
           type: string
           format: date-time
+    CreatePartitionInput:
+      type: object
+      properties:
+        begin:
+          type: string
+          format: date-time
+        days:
+          type: integer
     Error:
       type: object
       properties:

--- a/pkg/domain/storage.go
+++ b/pkg/domain/storage.go
@@ -8,8 +8,7 @@ import (
 
 // PartitionGenerator is used to generate the next time-based partition
 type PartitionGenerator interface {
-	GeneratePartition(context.Context) error
-	GeneratePartitionWithTimestamp(context.Context, time.Time) error
+	GeneratePartition(context.Context, time.Time, int) error
 }
 
 // PartitionsGetter is used to fetch a list of partitions

--- a/pkg/handlers/v1/create_partition.go
+++ b/pkg/handlers/v1/create_partition.go
@@ -8,9 +8,12 @@ import (
 	"github.com/asecurityteam/asset-inventory-api/pkg/logs"
 )
 
-// CreatePartitionInput takes an optional timestamp for which to create the new partition
+// CreatePartitionInput has two optional values
+// begin - the start date for the partition
+// days - the duration in number of days for which the partition will capture data
 type CreatePartitionInput struct {
-	Timestamp string `json:"timestamp"`
+	Begin time.Time `json:"begin"`
+	Days  int       `json:"days"`
 }
 
 // CreatePartitionHandler handles requests for creating the next time-based partition
@@ -21,22 +24,7 @@ type CreatePartitionHandler struct {
 
 // Handle handles the partition creation request
 func (h *CreatePartitionHandler) Handle(ctx context.Context, input CreatePartitionInput) error {
-	if input.Timestamp == "" {
-		err := h.Generator.GeneratePartition(ctx)
-		if err != nil {
-			h.LogFn(ctx).Error(logs.StorageError{Reason: err.Error()})
-		}
-		return err
-	}
-	t, err := time.Parse(time.RFC3339, input.Timestamp)
-	if err != nil {
-		h.LogFn(ctx).Info(logs.InvalidInput{Reason: err.Error()})
-		return InvalidInput{
-			Cause: err,
-			Field: "timestamp",
-		}
-	}
-	err = h.Generator.GeneratePartitionWithTimestamp(ctx, t)
+	err := h.Generator.GeneratePartition(ctx, input.Begin, input.Days)
 	if err != nil {
 		h.LogFn(ctx).Error(logs.StorageError{Reason: err.Error()})
 	}

--- a/pkg/handlers/v1/create_partition_test.go
+++ b/pkg/handlers/v1/create_partition_test.go
@@ -15,7 +15,7 @@ func TestCreatePartitionNoTime(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockGenerator := NewMockPartitionGenerator(ctrl)
-	mockGenerator.EXPECT().GeneratePartition(gomock.Any()).Return(nil)
+	mockGenerator.EXPECT().GeneratePartition(gomock.Any(), time.Time{}, 0).Return(nil)
 
 	h := &CreatePartitionHandler{
 		LogFn:     testLogFn,
@@ -31,7 +31,7 @@ func TestCreatePartitionNoTimeError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockGenerator := NewMockPartitionGenerator(ctrl)
-	mockGenerator.EXPECT().GeneratePartition(gomock.Any()).Return(errors.New(""))
+	mockGenerator.EXPECT().GeneratePartition(gomock.Any(), time.Time{}, 0).Return(errors.New(""))
 
 	h := &CreatePartitionHandler{
 		LogFn:     testLogFn,
@@ -39,55 +39,5 @@ func TestCreatePartitionNoTimeError(t *testing.T) {
 	}
 
 	err := h.Handle(context.Background(), CreatePartitionInput{})
-	assert.Error(t, err)
-}
-
-func TestPartitionTime(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockGenerator := NewMockPartitionGenerator(ctrl)
-	mockGenerator.EXPECT().GeneratePartitionWithTimestamp(gomock.Any(), gomock.Any()).Return(nil)
-
-	h := &CreatePartitionHandler{
-		LogFn:     testLogFn,
-		Generator: mockGenerator,
-	}
-
-	ts := time.Now().Format(time.RFC3339)
-
-	err := h.Handle(context.Background(), CreatePartitionInput{Timestamp: ts})
-	assert.NoError(t, err)
-}
-
-func TestPartitionTimeError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockGenerator := NewMockPartitionGenerator(ctrl)
-	mockGenerator.EXPECT().GeneratePartitionWithTimestamp(gomock.Any(), gomock.Any()).Return(errors.New(""))
-
-	h := &CreatePartitionHandler{
-		LogFn:     testLogFn,
-		Generator: mockGenerator,
-	}
-
-	ts := time.Now().Format(time.RFC3339)
-
-	err := h.Handle(context.Background(), CreatePartitionInput{Timestamp: ts})
-	assert.Error(t, err)
-}
-
-func TestPartitionTimeBadTimestamp(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	h := &CreatePartitionHandler{
-		LogFn: testLogFn,
-	}
-
-	ts := "not a valid ts"
-
-	err := h.Handle(context.Background(), CreatePartitionInput{Timestamp: ts})
 	assert.Error(t, err)
 }

--- a/pkg/handlers/v1/mock_storage_test.go
+++ b/pkg/handlers/v1/mock_storage_test.go
@@ -4,10 +4,11 @@
 package v1
 
 import (
-	context "context"
+	"context"
+	"time"
+
 	"github.com/asecurityteam/asset-inventory-api/pkg/domain"
-	gomock "github.com/golang/mock/gomock"
-	time "time"
+	"github.com/golang/mock/gomock"
 )
 
 // Mock of PartitionGenerator interface
@@ -31,24 +32,14 @@ func (_m *MockPartitionGenerator) EXPECT() *_MockPartitionGeneratorRecorder {
 	return _m.recorder
 }
 
-func (_m *MockPartitionGenerator) GeneratePartition(_param0 context.Context) error {
-	ret := _m.ctrl.Call(_m, "GeneratePartition", _param0)
+func (_m *MockPartitionGenerator) GeneratePartition(_param0 context.Context, _param1 time.Time, _param2 int) error {
+	ret := _m.ctrl.Call(_m, "GeneratePartition", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockPartitionGeneratorRecorder) GeneratePartition(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GeneratePartition", arg0)
-}
-
-func (_m *MockPartitionGenerator) GeneratePartitionWithTimestamp(_param0 context.Context, _param1 time.Time) error {
-	ret := _m.ctrl.Call(_m, "GeneratePartitionWithTimestamp", _param0, _param1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockPartitionGeneratorRecorder) GeneratePartitionWithTimestamp(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GeneratePartitionWithTimestamp", arg0, arg1)
+func (_mr *_MockPartitionGeneratorRecorder) GeneratePartition(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GeneratePartition", arg0, arg1, arg2)
 }
 
 // Mock of PartitionsGetter interface


### PR DESCRIPTION
Currently, the database partitions are hardcoded to 3 months. This PR makes a couple of adjustments:

- Change the default partition from 3 months to 90 days
- allows callers to specify a custom partition duration in # of days