### PR TITLE
add delete partitions function

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -281,6 +281,43 @@ paths:
           async: false
           success: '{"status": 200, "bodyPassthrough": true}'
           error: '{"status": 500, "bodyPassthrough": true}'
+    delete:
+      summary: "Delete old partitions"
+      description: "This is an endpoint to delete partitions older than the specified number of days."
+      parameters:
+        - name: days
+          in: query
+          description: "Optional age in days. If none is specified the serivce default will be used"
+          required: false
+          schema:
+            type: integer
+      responses:
+        200:
+          description: "Successfully deleted"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedPartitions'
+      x-transportd:
+        backend: app
+        enabled:
+          - "metrics"
+          - "accesslog"
+          - "requestvalidation"
+          - "responsevalidation"
+          - "lambda"
+        lambda:
+          arn: "deletePartitions"
+          async: false
+          request: >
+            {
+              #! if .Request.Query.days !#
+              "days": #!index .Request.Query.days 0!#
+              #! end !#
+            }
+          success: '{"status": 200, "bodyPassthrough": true}'
+          error: '{"status": 500, "bodyPassthrough": true}'
+
 components:
   schemas:
     CloudAssetChanges:
@@ -394,6 +431,11 @@ components:
           type: string
           format: date-time
         days:
+          type: integer
+    DeletedPartitions:
+      type: object
+      properties:
+        deleted:
           type: integer
     Error:
       type: object

--- a/main.go
+++ b/main.go
@@ -46,12 +46,17 @@ func main() {
 		LogFn:  domain.LoggerFromContext,
 		Getter: dbStorage,
 	}
+	deletePartitions := &v1.DeletePartitionsHandler{
+		LogFn:   domain.LoggerFromContext,
+		Deleter: dbStorage,
+	}
 	handlers := map[string]serverfull.Function{
-		"insert":          serverfull.NewFunction(insert.Handle),
-		"fetchByIP":       serverfull.NewFunction(fetchByIP.Handle),
-		"fetchByHostname": serverfull.NewFunction(fetchByHostname.Handle),
-		"createPartition": serverfull.NewFunction(createPartition.Handle),
-		"getPartitions":   serverfull.NewFunction(getPartitions.Handle),
+		"insert":           serverfull.NewFunction(insert.Handle),
+		"fetchByIP":        serverfull.NewFunction(fetchByIP.Handle),
+		"fetchByHostname":  serverfull.NewFunction(fetchByHostname.Handle),
+		"createPartition":  serverfull.NewFunction(createPartition.Handle),
+		"getPartitions":    serverfull.NewFunction(getPartitions.Handle),
+		"deletePartitions": serverfull.NewFunction(deletePartitions.Handle),
 	}
 
 	fetcher := &serverfull.StaticFetcher{Functions: handlers}

--- a/pkg/domain/storage.go
+++ b/pkg/domain/storage.go
@@ -16,6 +16,11 @@ type PartitionsGetter interface {
 	GetPartitions(context.Context) ([]Partition, error)
 }
 
+// PartitionsDeleter is used to drop partitions older than the specified number of days
+type PartitionsDeleter interface {
+	DeletePartitions(context.Context, int) (int, error)
+}
+
 // CloudAssetStorer interface provides functions for inserting cloud assets
 type CloudAssetStorer interface {
 	Store(context.Context, CloudAssetChanges) error

--- a/pkg/handlers/v1/delete_partitions.go
+++ b/pkg/handlers/v1/delete_partitions.go
@@ -1,0 +1,36 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/asecurityteam/asset-inventory-api/pkg/domain"
+	"github.com/asecurityteam/asset-inventory-api/pkg/logs"
+)
+
+// DeletePartitionsInput has an optional value, days, which is the age of partitions to delete
+type DeletePartitionsInput struct {
+	Days int `json:"days"`
+}
+
+// DeletePartitionsOutput returns the number of partitions which were deleted
+type DeletePartitionsOutput struct {
+	Deleted int `json:"deleted"`
+}
+
+// DeletePartitionsHandler handles requests for deleting partitions
+type DeletePartitionsHandler struct {
+	LogFn   domain.LogFn
+	Deleter domain.PartitionsDeleter
+}
+
+// Handle handles the partition creation request
+func (h *DeletePartitionsHandler) Handle(ctx context.Context, input DeletePartitionsInput) (DeletePartitionsOutput, error) {
+	result, err := h.Deleter.DeletePartitions(ctx, input.Days)
+	if err != nil {
+		h.LogFn(ctx).Error(logs.StorageError{Reason: err.Error()})
+		return DeletePartitionsOutput{}, err
+	}
+	return DeletePartitionsOutput{
+		Deleted: result,
+	}, nil
+}

--- a/pkg/handlers/v1/delete_partitions_test.go
+++ b/pkg/handlers/v1/delete_partitions_test.go
@@ -1,0 +1,47 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeletePartitions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	days := 365
+
+	mockDeleter := NewMockPartitionsDeleter(ctrl)
+	mockDeleter.EXPECT().DeletePartitions(gomock.Any(), days).Return(10, nil)
+
+	h := &DeletePartitionsHandler{
+		LogFn:   testLogFn,
+		Deleter: mockDeleter,
+	}
+
+	res, err := h.Handle(context.Background(), DeletePartitionsInput{Days: days})
+	assert.NoError(t, err)
+	assert.Equal(t, 10, res.Deleted)
+}
+
+func TestDeletePartitionsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	days := 365
+
+	mockDeleter := NewMockPartitionsDeleter(ctrl)
+	mockDeleter.EXPECT().DeletePartitions(gomock.Any(), days).Return(0, errors.New(""))
+
+	h := &DeletePartitionsHandler{
+		LogFn:   testLogFn,
+		Deleter: mockDeleter,
+	}
+
+	_, err := h.Handle(context.Background(), DeletePartitionsInput{Days: days})
+	assert.Error(t, err)
+}

--- a/pkg/handlers/v1/mock_storage_test.go
+++ b/pkg/handlers/v1/mock_storage_test.go
@@ -4,11 +4,10 @@
 package v1
 
 import (
-	"context"
-	"time"
-
+	context "context"
 	"github.com/asecurityteam/asset-inventory-api/pkg/domain"
-	"github.com/golang/mock/gomock"
+	gomock "github.com/golang/mock/gomock"
+	time "time"
 )
 
 // Mock of PartitionGenerator interface
@@ -72,6 +71,38 @@ func (_m *MockPartitionsGetter) GetPartitions(_param0 context.Context) ([]domain
 
 func (_mr *_MockPartitionsGetterRecorder) GetPartitions(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPartitions", arg0)
+}
+
+// Mock of PartitionsDeleter interface
+type MockPartitionsDeleter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockPartitionsDeleterRecorder
+}
+
+// Recorder for MockPartitionsDeleter (not exported)
+type _MockPartitionsDeleterRecorder struct {
+	mock *MockPartitionsDeleter
+}
+
+func NewMockPartitionsDeleter(ctrl *gomock.Controller) *MockPartitionsDeleter {
+	mock := &MockPartitionsDeleter{ctrl: ctrl}
+	mock.recorder = &_MockPartitionsDeleterRecorder{mock}
+	return mock
+}
+
+func (_m *MockPartitionsDeleter) EXPECT() *_MockPartitionsDeleterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockPartitionsDeleter) DeletePartitions(_param0 context.Context, _param1 int) (int, error) {
+	ret := _m.ctrl.Call(_m, "DeletePartitions", _param0, _param1)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockPartitionsDeleterRecorder) DeletePartitions(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePartitions", arg0, arg1)
 }
 
 // Mock of CloudAssetStorer interface

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -13,6 +13,7 @@ type PostgresConfig struct {
 	Username     string
 	Password     string
 	DatabaseName string
+	PartitionTTL int
 }
 
 // Name is used by the settings library to replace the default naming convention.

--- a/pkg/storage/config_test.go
+++ b/pkg/storage/config_test.go
@@ -8,7 +8,14 @@ import (
 )
 
 func TestName(t *testing.T) {
-	postgresConfig := PostgresConfig{"localhost", "99", "me!", "mypassword!", "name"}
+	postgresConfig := PostgresConfig{
+		Hostname:     "localhost",
+		Port:         "99",
+		Username:     "me!",
+		Password:     "mypassword!",
+		DatabaseName: "name",
+		PartitionTTL: 365,
+	}
 	assert.Equal(t, "Postgres", postgresConfig.Name())
 }
 


### PR DESCRIPTION
We have provided a way to create partitions. This will eventually result in the number of partitions growing at an unbounded rate. To address this, this PR adds a DELETE endpoint which will delete all partitions older than the specified number of days.

This PR does not include a mechanism to export data or archive data. If needed, that work will come later. Today this can be done by other (less elegant) ways such as restoring a database backup.