### PR TITLE
Switch db reads to replica

### DIFF
--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -47,7 +47,7 @@ func (*PostgresConfigComponent) New(ctx context.Context, c *PostgresConfig) (*DB
 	db := &DB{
 		scripts: scripts.FindString,
 	}
-	if err := db.Init(ctx, c.Hostname, c.Port, c.Username, c.Password, c.DatabaseName, c.PartitionTTL); err != nil {
+	if err := db.Init(ctx, c.Hostname, c.Port, c.Username, c.Password, c.DatabaseName, c.PartitionTTL, false); err != nil {
 		return nil, err
 	}
 	return db, nil

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -9,9 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/asecurityteam/asset-inventory-api/pkg/domain"
 	_ "github.com/lib/pq" // must remain here for sql lib to find the postgres driver
 	"github.com/pkg/errors"
+
+	"github.com/asecurityteam/asset-inventory-api/pkg/domain"
 )
 
 const (
@@ -117,7 +118,7 @@ func (db *DB) RunScript(ctx context.Context, name string) error {
 }
 
 // Init initializes a connection to a Postgres database according to the environment variables POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DATABASE
-func (db *DB) Init(ctx context.Context, host string, port uint16, user string, password string, dbname string, partitionTTL int,  readOnly bool) error {
+func (db *DB) Init(ctx context.Context, host string, port uint16, user string, password string, dbname string, partitionTTL int, readOnly bool) error {
 	var initerr error
 	db.once.Do(func() {
 

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -117,7 +117,7 @@ func (db *DB) RunScript(ctx context.Context, name string) error {
 }
 
 // Init initializes a connection to a Postgres database according to the environment variables POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DATABASE
-func (db *DB) Init(ctx context.Context, host string, port uint16, user string, password string, dbname string, partitionTTL int) error {
+func (db *DB) Init(ctx context.Context, host string, port uint16, user string, password string, dbname string, partitionTTL int,  readOnly bool) error {
 	var initerr error
 	db.once.Do(func() {
 
@@ -151,7 +151,7 @@ func (db *DB) Init(ctx context.Context, host string, port uint16, user string, p
 				return // from the unnamed once.Do function
 			}
 
-			if !dbExists {
+			if !dbExists && !readOnly {
 				err = db.create(dbname)
 				if err != nil {
 					initerr = err
@@ -175,7 +175,9 @@ func (db *DB) Init(ctx context.Context, host string, port uint16, user string, p
 			}
 
 		}
-		initerr = db.RunScript(ctx, createScript)
+		if !readOnly {
+			initerr = db.RunScript(ctx, createScript)
+		}
 
 	})
 	return initerr

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -30,7 +30,7 @@ func TestDBInitHandleOpenError(t *testing.T) {
 	databasename := "name"
 	partitionTTL := 2
 
-	if err := thedb.Init(context.Background(), hostname, port, username, password, databasename, partitionTTL); err == nil {
+	if err := thedb.Init(context.Background(), hostname, port, username, password, databasename, partitionTTL, true); err == nil {
 		t.Errorf("DB.Init should have returned a non-nil error")
 	}
 }

--- a/pkg/storage/read_config.go
+++ b/pkg/storage/read_config.go
@@ -42,7 +42,7 @@ func (*PostgresReadConfigComponent) Settings() *PostgresReadConfig {
 // New - Unlike Master, Replica DB has no scripts and does not attempt to create the database as it can not by definition
 func (*PostgresReadConfigComponent) New(ctx context.Context, c *PostgresReadConfig) (*DB, error) {
 	db := &DB{}
-	if err := db.Init(ctx, c.Hostname, c.Port, c.Username, c.Password, c.DatabaseName, c.PartitionTTL); err != nil {
+	if err := db.Init(ctx, c.Hostname, c.Port, c.Username, c.Password, c.DatabaseName, c.PartitionTTL, true); err != nil {
 		return nil, err
 	}
 	return db, nil


### PR DESCRIPTION
Prevent replica DB connection initialization from attempting to create database and manage schema.
This is the final pass re: read replica support. The Docker image with changes from this branch is functional and correctly directs reads to replica.
NB - the schema management logic is going to change once we have tooling in place.