### PR TITLE
Switch partition count operation to main

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func (c *component) New(ctx context.Context, conf *config) (func(context.Context
 	}
 	getPartitions := &v1.GetPartitionsHandler{
 		LogFn:  domain.LoggerFromContext,
-		Getter: readDbStorage,
+		Getter: dbStorage,
 	}
 	deletePartitions := &v1.DeletePartitionsHandler{
 		LogFn:   domain.LoggerFromContext,


### PR DESCRIPTION
It has way better performance on main compared to replica. Our current check fails (times out) when this is run on replica as the call relies on bunch of `select count (*) from table` (one per partition). Long term plan is to get rid of/change the way we partition.