### PR TITLE
Normalized schema

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -76,10 +76,10 @@ from aws_private_ip_assignment ia
 where ia.private_ip = $1
   and ia.not_before < $2
   and (ia.not_after is null or ia.not_after > $2)
-`
+` // nolint: varcheck
 
 // Query to find resource by public IP using v2 schema
-const resourceByPublicIpQuery = `select ia.public_ip,
+const resourceByPublicIPQuery = `select ia.public_ip,
        res.arn_id,
        res.meta,
        ar.region,
@@ -93,7 +93,7 @@ from aws_public_ip_assignment ia
 where ia.public_ip = $1
   and ia.not_before < $2
   and (ia.not_after is null or ia.not_after > $2)
-`
+` // nolint: varcheck
 
 // Query to find resource by hostname using v2 schema
 const resourceByHostnameQuery = `select ia.aws_hostname,
@@ -110,7 +110,7 @@ from aws_public_ip_assignment ia
 where ia.aws_hostname = $1
   and ia.not_before < $2
   and (ia.not_after is null or ia.not_after > $2)
-`
+` // nolint: varcheck
 
 // This query is used to retrieve all the 'active' resources (i.e. those with assigned IP/Hostname) for specific date
 const bulkResourcesQuery = `
@@ -139,7 +139,7 @@ LIMIT $3
 OFFSET $4
 `
 
-//TODO Optimized query to retrieve all the 'active' resources utilising v2 schema. Out of scope currently.
+//TODO Optimized query to retrieve all the 'active' resources utilizing v2 schema. Out of scope currently.
 
 // DB represents a convenient database abstraction layer
 type DB struct {

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -61,8 +61,58 @@ const latestStatusQuery = "WITH latest_candidates AS ( " +
 	"    aws_resources ON " +
 	"        latest.aws_resources_id = aws_resources.id;"
 
+// Query to find resource by private IP using v2 schema
+const resourceByPrivateIPQuery = `select ia.private_ip,
+       res.arn_id,
+       res.meta,
+       ar.region,
+       rt.resource_type,
+       aa.account
+from aws_private_ip_assignment ia
+         left join aws_resource res on ia.aws_resource_id = res.id
+         left join aws_region ar on res.aws_account_id = ar.id
+         left join aws_resource_type rt on res.aws_resource_type_id = rt.id
+         left join aws_account aa on res.aws_account_id = aa.id
+where ia.private_ip = $1
+  and ia.not_before < $2
+  and (ia.not_after is null or ia.not_after > $2)
+`
+
+// Query to find resource by public IP using v2 schema
+const resourceByPublicIpQuery = `select ia.public_ip,
+       res.arn_id,
+       res.meta,
+       ar.region,
+       rt.resource_type,
+       aa.account
+from aws_public_ip_assignment ia
+         left join aws_resource res on ia.aws_resource_id = res.id
+         left join aws_region ar on res.aws_account_id = ar.id
+         left join aws_resource_type rt on res.aws_resource_type_id = rt.id
+         left join aws_account aa on res.aws_account_id = aa.id
+where ia.public_ip = $1
+  and ia.not_before < $2
+  and (ia.not_after is null or ia.not_after > $2)
+`
+
+// Query to find resource by hostname using v2 schema
+const resourceByHostnameQuery = `select ia.aws_hostname,
+       res.arn_id,
+       res.meta,
+       ar.region,
+       rt.resource_type,
+       aa.account
+from aws_public_ip_assignment ia
+         left join aws_resource res on ia.aws_resource_id = res.id
+         left join aws_region ar on res.aws_account_id = ar.id
+         left join aws_resource_type rt on res.aws_resource_type_id = rt.id
+         left join aws_account aa on res.aws_account_id = aa.id
+where ia.aws_hostname = $1
+  and ia.not_before < $2
+  and (ia.not_after is null or ia.not_after > $2)
+`
+
 // This query is used to retrieve all the 'active' resources (i.e. those with assigned IP/Hostname) for specific date
-// TODO - run performance analysis, possibly do something else on SQL level (optimize query or adjust schema)
 const bulkResourcesQuery = `
 WITH lc AS (
 	SELECT
@@ -88,6 +138,8 @@ ORDER BY lc.ts DESC
 LIMIT $3
 OFFSET $4
 `
+
+//TODO Optimized query to retrieve all the 'active' resources utilising v2 schema. Out of scope currently.
 
 // DB represents a convenient database abstraction layer
 type DB struct {

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -62,6 +62,7 @@ const latestStatusQuery = "WITH latest_candidates AS ( " +
 	"        latest.aws_resources_id = aws_resources.id;"
 
 // Query to find resource by private IP using v2 schema
+// nolint
 const resourceByPrivateIPQuery = `select ia.private_ip,
        res.arn_id,
        res.meta,
@@ -76,9 +77,10 @@ from aws_private_ip_assignment ia
 where ia.private_ip = $1
   and ia.not_before < $2
   and (ia.not_after is null or ia.not_after > $2)
-` // nolint: varcheck
+`
 
 // Query to find resource by public IP using v2 schema
+// nolint
 const resourceByPublicIPQuery = `select ia.public_ip,
        res.arn_id,
        res.meta,
@@ -93,9 +95,10 @@ from aws_public_ip_assignment ia
 where ia.public_ip = $1
   and ia.not_before < $2
   and (ia.not_after is null or ia.not_after > $2)
-` // nolint: varcheck
+`
 
 // Query to find resource by hostname using v2 schema
+// nolint
 const resourceByHostnameQuery = `select ia.aws_hostname,
        res.arn_id,
        res.meta,
@@ -110,7 +113,7 @@ from aws_public_ip_assignment ia
 where ia.aws_hostname = $1
   and ia.not_before < $2
   and (ia.not_after is null or ia.not_after > $2)
-` // nolint: varcheck
+`
 
 // This query is used to retrieve all the 'active' resources (i.e. those with assigned IP/Hostname) for specific date
 const bulkResourcesQuery = `

--- a/scripts/3_create_v2.sql
+++ b/scripts/3_create_v2.sql
@@ -36,7 +36,7 @@ create table aws_public_ip_assignment
     id              bigserial primary key,
     not_before      timestamp not null,
     not_after       timestamp,
-    public_ip       inet,
+    public_ip       inet not null,
     aws_hostname    varchar   not null,
     aws_resource_id bigint    not null,
     foreign key (aws_resource_id) references aws_resource (id)
@@ -51,7 +51,7 @@ create table aws_private_ip_assignment
     id              bigserial primary key,
     not_before      timestamp not null,
     not_after       timestamp,
-    private_ip      inet,
+    private_ip      inet not null,
     aws_resource_id int       not null,
     foreign key (aws_resource_id) references aws_resource (id)
 );

--- a/scripts/3_create_v2.sql
+++ b/scripts/3_create_v2.sql
@@ -1,0 +1,57 @@
+create table aws_region
+(
+    id     serial primary key,
+    region varchar not null unique
+);
+
+create table aws_account
+(
+    id      serial primary key,
+    account varchar not null unique
+);
+
+
+create table aws_resource_type
+(
+    id            serial primary key,
+    resource_type varchar not null unique
+);
+
+create table aws_resource
+(
+    id                   bigserial primary key,
+    arn_id               varchar not null, /* nb, this is NOT full arn, it is resource ID like i-5325235 as ARN is redundant and can be reconstructed */
+    aws_account_id       int     not null, /* the account, type and region are immutable, so the lookup tables are referenced as the part of resource, not event */
+    foreign key (aws_account_id) references aws_account (id),
+    aws_region_id        int     not null,
+    foreign key (aws_region_id) references aws_region (id),
+    aws_resource_type_id int     not null,
+    foreign key (aws_resource_type_id) references aws_resource_type (id),
+    meta                 JSONB /* this is not optimal and is not correct as tags can change and changes need tracking */
+);
+
+
+create table aws_public_ip_assignment
+(
+    id              bigserial primary key,
+    not_before      timestamp not null,
+    not_after       timestamp,
+    public_ip       inet,
+    aws_hostname    varchar   not null,
+    aws_resource_id bigint    not null,
+    foreign key (aws_resource_id) references aws_resource (id)
+);
+create index idx_public_ip on aws_public_ip_assignment (public_ip);
+create index idx_aws_hostname on aws_public_ip_assignment (aws_hostname);
+
+create table aws_private_ip_assignment
+(
+    id              bigserial primary key,
+    not_before      timestamp not null,
+    not_after       timestamp,
+    private_ip      inet,
+    aws_resource_id int       not null,
+    foreign key (aws_resource_id) references aws_resource (id)
+);
+
+create index idx_private_ip on aws_private_ip_assignment (private_ip);

--- a/scripts/3_create_v2.sql
+++ b/scripts/3_create_v2.sql
@@ -41,7 +41,9 @@ create table aws_public_ip_assignment
     aws_resource_id bigint    not null,
     foreign key (aws_resource_id) references aws_resource (id)
 );
+
 create index idx_public_ip on aws_public_ip_assignment (public_ip);
+
 create index idx_aws_hostname on aws_public_ip_assignment (aws_hostname);
 
 create table aws_private_ip_assignment


### PR DESCRIPTION
The proposed new schema (with manual migration and performance testing so far, automation for both is to be done in scope of different PRs) was tested for performance comparison with existing one using the queries in this PR and production-like data. 
The storage was populated (for both cases) with ~10 mln resources and ~45 mln allocation/de-allocation events.
The query execution time for look-ups  (both hits and misses) using new schema did not exceed 100ms, which brings us well within reasonable execution time per request.

Caveats:
* not ALL the queries using old schema resulted in multi-second look-ups, but some  took 5+ seconds to complete with the data set I used. 
* the new schema was specifically compared against worst performing cases for current schema, and is more predictable performance wise (i.e. varies less)
* the partitioning is no longer used, as there is no way to effectively partition on time (the open date of the event can be at any point in the past, so we would have to potentially keep partitions forever). In addition, based on the numbers from performance tests with proposed schema changes the additional complexity of maintaining partitions is not justified as the performance is good enough as-is
