### PR TITLE
Dual-write events to new and old schema based on present schema version

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -873,7 +873,8 @@ $$
         update aws_public_ip_assignment
         set not_after=$1
         where public_ip = $2
-          and aws_resource_id = (select id from aws_resource where arn_id = $3);
+          and aws_resource_id = (select id from aws_resource where arn_id = $3)
+          and aws_hostname = $4;
         if not found then
             insert into aws_public_ip_assignment
                 (not_before, not_after, public_ip, aws_resource_id, aws_hostname)

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -482,9 +482,11 @@ func (db *DB) Store(ctx context.Context, cloudAssetChanges domain.CloudAssetChan
 	if err != nil || ver < DualWriteSchemaVersion {
 		return nil
 	}
-	return db.storeV2(ctx, cloudAssetChanges)
+	return db.StoreV2(ctx, cloudAssetChanges)
 }
-func (db *DB) storeV2(ctx context.Context, cloudAssetChanges domain.CloudAssetChanges) error {
+
+// StoreV2 an implementation of the Storage interface that records to a database using new schema, to replace Store
+func (db *DB) StoreV2(ctx context.Context, cloudAssetChanges domain.CloudAssetChanges) error {
 	tx, err := db.sqldb.Begin()
 	if err != nil {
 		return err

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -485,7 +485,7 @@ func (db *DB) Store(ctx context.Context, cloudAssetChanges domain.CloudAssetChan
 	return db.StoreV2(ctx, cloudAssetChanges)
 }
 
-// StoreV2 an implementation of the Storage interface that records to a database using new schema, to replace Store
+// StoreV2 Currently public to allow testing separately.Storage interface implementation that records to a database using new schema, to replace Store in the future.
 func (db *DB) StoreV2(ctx context.Context, cloudAssetChanges domain.CloudAssetChanges) error {
 	tx, err := db.sqldb.Begin()
 	if err != nil {

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -175,8 +175,14 @@ func TestGoldenPath(t *testing.T) {
 	}
 	defer mockdb.Close()
 
-	thedb := DB{
-		sqldb: mockdb,
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockMigrator := NewMockStorageMigrator(ctrl)
+	mockMigrator.EXPECT().Version().Return(MinimumSchemaVersion, false, nil)
+
+	theDB := DB{
+		sqldb:    mockdb,
+		migrator: mockMigrator,
 	}
 
 	mock.ExpectBegin()
@@ -191,7 +197,7 @@ func TestGoldenPath(t *testing.T) {
 
 	ctx := context.Background()
 
-	if err = thedb.Store(ctx, fakeCloudAssetChanges()); err != nil {
+	if err = theDB.Store(ctx, fakeCloudAssetChanges()); err != nil {
 		t.Errorf("error was not expected while saving resource: %s", err)
 	}
 


### PR DESCRIPTION
~~NB, this will be updated to cover the new code path with tests properly, but otherwise looks complete. Considering that's a lot of SQL to review, throwing it in early.~~ Tests are there.

Based on the current schema version, after the existing code wrote the event to the existing schema, if the migration to add new tables was complete, the storeV2() is invoked to perform additional write to new schema.
The db inserts are written with possibility of out-of-band and out-of-order events, for example release event arriving before assign (e.g. dual writes and subsequent back-fill) in mind.
Special timestamp value is used to express 'unknown assignment date' to allow for catch-up update to record an assignment after the release event was already recorded.
Public IPs assignments always arrive with matching collection of hostnames (verified across all known data in production), so there is no separate recording of hostname assign/free events.
Out of scope - tracking tag/metadata changes.

