### PR TITLE
Add reads (hostname) for new schema

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -753,7 +753,7 @@ func (db *DB) runQuery(ctx context.Context, version uint, query string, args ...
 		var isJoin bool      // no need for sql.NullBool as the DB column is guaranteed a value
 		var timestamp time.Time
 
-		if version < DualWritesSchemaVersion {
+		if version < ReadsFromNewSchemaVersion {
 			err = rows.Scan(&row.ARN, &ipAddress, &hostname, &isPublic, &isJoin, &timestamp, &row.AccountID, &row.Region, &row.ResourceType, &metaBytes)
 		} else {
 			err = rows.Scan(&ipAddress, &hostname, &row.ARN, &metaBytes, &row.Region, &row.ResourceType, &row.AccountID)

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -715,7 +715,7 @@ func (db *DB) FetchByHostname(ctx context.Context, when time.Time, hostname stri
 		return nil, err
 	}
 	var assets []domain.CloudAssetDetails
-	if ver < DualWritesSchemaVersion {
+	if ver < ReadsFromNewSchemaVersion {
 		sqlstmt := fmt.Sprintf(latestStatusQuery, `aws_hostnames_hostname`)
 		assets, err = db.runQuery(ctx, ver, sqlstmt, hostname, when)
 	} else {


### PR DESCRIPTION
Adding reads for hostname from new schema. Still need to test locally but wanted to get early feedback. 
- small edits to resourceByHostname query
- updated tests

Waiting on SID-219 and SID-220, I will pull those changes before merging this.