### PR TITLE
Update fetch assets by private and public IP to match M1 schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
 	github.com/gobuffalo/genny v0.1.1 // indirect
 	github.com/gobuffalo/gogen v0.1.1 // indirect
-	github.com/gobuffalo/packr/v2 v2.2.0
 	github.com/golang-migrate/migrate/v4 v4.8.0
 	github.com/golang/mock v1.4.0
 	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da // indirect

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -87,39 +87,40 @@ const latestStatusQuery = "WITH latest_candidates AS ( " +
 
 // Query to find resource by private IP using v2 schema
 // nolint
-const resourceByPrivateIPQuery = "SELECT ia.private_ip, " +
-	"			res.arn_id, " +
-	"			res.meta, " +
-	"			ar.region, " +
-	"			rt.resource_type, " +
-	"			aa.account " +
-	"	FROM aws_private_ip_assignment ia " +
-	"		LEFT JOIN aws_resource res ON ia.aws_resource_id = res.id " +
-	"		LEFT JOIN aws_region ar ON res.aws_region_id = ar.id " +
-	"		LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id " +
-	"		LEFT JOIN aws_account aa ON res.aws_account_id = aa.id " +
-	"	WHERE ia.private_ip = $1 " +
-	"		AND ia.not_before < $2 " +
-	"		AND (ia.not_after IS NULL OR ia.not_after > $2);"
+const resourceByPrivateIPQuery = `select ia.private_ip,
+       res.arn_id,
+       res.meta,
+       ar.region,
+       rt.resource_type,
+       aa.account
+from aws_private_ip_assignment ia
+         left join aws_resource res on ia.aws_resource_id = res.id
+         left join aws_region ar on res.aws_region_id = ar.id
+         left join aws_resource_type rt on res.aws_resource_type_id = rt.id
+         left join aws_account aa on res.aws_account_id = aa.id
+where ia.private_ip = $1
+  and ia.not_before < $2
+  and (ia.not_after is null or ia.not_after > $2)
+`
 
 // Query to find resource by public IP using v2 schema
 // nolint
-const resourceByPublicIPQuery = "SELECT " +
-	"			ia.public_ip, " +
-	"			ia.hostname, " +
-	"			res.arn_id, " +
-	"			res.meta, " +
-	"			ar.region, " +
-	"			rt.resource_type, " +
-	"			aa.account " +
-	"	FROM aws_public_ip_assignment ia " +
-	"		LEFT JOIN aws_resource res ON ia.aws_resource_id = res.id " +
-	"		LEFT JOIN aws_region ar ON res.aws_region_id = ar.id " +
-	"		LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id " +
-	"		LEFT JOIN aws_account aa ON res.aws_account_id = aa.id " +
-	"	WHERE ia.public_ip = $1 " +
-	"		AND ia.not_before < $2 " +
-	"		AND (ia.not_after is null or ia.not_after > $2);"
+const resourceByPublicIPQuery = `select ia.public_ip,
+	   ia.hostname,
+       res.arn_id,
+       res.meta,
+       ar.region,
+       rt.resource_type,
+       aa.account
+from aws_public_ip_assignment ia
+         left join aws_resource res on ia.aws_resource_id = res.id
+         left join aws_region ar on res.aws_region_id = ar.id
+         left join aws_resource_type rt on res.aws_resource_type_id = rt.id
+         left join aws_account aa on res.aws_account_id = aa.id
+where ia.public_ip = $1
+  and ia.not_before < $2
+  and (ia.not_after is null or ia.not_after > $2)
+`
 
 // Query to find resource by hostname using v2 schema
 // nolint

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -739,6 +739,9 @@ func (db *DB) FetchByIP(ctx context.Context, when time.Time, ipAddress string) (
 		asset, err = db.runQuery(ctx, sqlstmt, ipAddress, when)
 	} else {
 		ipaddr := net.ParseIP(ipAddress)
+		if ipaddr == nil {
+			return nil, errors.New("invalid IP address")
+		}
 		if isPrivateIP(ipaddr) {
 			asset, err = db.runFetchByIPQuery(ctx, true, resourceByPrivateIPQuery, ipAddress, when)
 		} else {

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -178,6 +178,21 @@ type DB struct {
 	defaultPartitionTTL int
 }
 
+var privateIPNetworks = []net.IPNet{
+	net.IPNet{
+		IP:   net.IPv4(192, 168, 1, 0),
+		Mask: net.IPv4Mask(255, 255, 0, 0),
+	},
+	net.IPNet{
+		IP:   net.IPv4(172, 16, 0, 0),
+		Mask: net.IPv4Mask(255, 240, 0, 0),
+	},
+	net.IPNet{
+		IP:   net.IPv4(10, 0, 0, 0),
+		Mask: net.IPv4Mask(255, 0, 0, 0),
+	},
+}
+
 // ForceSchemaToVersion sets the database schema to specified version without running any migrations and clears dirty flag
 func (db *DB) ForceSchemaToVersion(ctx context.Context, version uint) error {
 	return db.migrator.Force(int(version))
@@ -734,18 +749,6 @@ func (db *DB) FetchByIP(ctx context.Context, when time.Time, ipAddress string) (
 }
 
 func isPrivateIP(ip net.IP) bool {
-	privateIPNetworks := make([]*net.IPNet, 0, 3)
-	for _, cidr := range []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-	} {
-		_, network, err := net.ParseCIDR(cidr)
-		if err != nil {
-			panic(fmt.Errorf("fail to parse %q: %v", cidr, err))
-		}
-		privateIPNetworks = append(privateIPNetworks, network)
-	}
 	for _, net := range privateIPNetworks {
 		if net.Contains(ip) {
 			return true

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -207,19 +207,25 @@ func TestGoldenPath(t *testing.T) {
 	}
 }
 
-func TestGetIPsAtTime(t *testing.T) {
+func TestGetIPsAtTimeLegacySchema(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	version := uint(1)
+	migrator := NewMockStorageMigrator(ctrl)
+	migrator.EXPECT().Version().Return(version, false, nil)
 	mockdb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
 
-	thedb := DB{
-		sqldb: mockdb,
+	thedb := &DB{
+		migrator: migrator,
+		sqldb:    mockdb,
 	}
 
 	at, _ := time.Parse(time.RFC3339, "2019-04-09T08:55:35+00:00")
-	ipAddress := "9.8.7.6"
+	ipAddress := "9.8.7.6" //nolint
 	rowts := "2019-01-15T08:19:22+00:00"
 	rowtsTime, _ := time.Parse(time.RFC3339, rowts)
 
@@ -247,15 +253,21 @@ func TestGetIPsAtTime(t *testing.T) {
 	}
 }
 
-func TestGetIPsAtTimeMultiRows(t *testing.T) {
+func TestGetIPsAtTimeMultiRowsLegacySchema(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	version := uint(1)
+	migrator := NewMockStorageMigrator(ctrl)
+	migrator.EXPECT().Version().Return(version, false, nil)
 	mockdb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
 
-	thedb := DB{
-		sqldb: mockdb,
+	thedb := &DB{
+		migrator: migrator,
+		sqldb:    mockdb,
 	}
 
 	at, _ := time.Parse(time.RFC3339, "2019-04-09T08:55:35+00:00")
@@ -286,6 +298,253 @@ func TestGetIPsAtTimeMultiRows(t *testing.T) {
 		domain.CloudAssetDetails{
 			PublicIPAddresses: []string{"99.88.77.66"},
 			Hostnames:         []string{"google.com"},
+			ResourceType:      "type2",
+			AccountID:         "aid2",
+			Region:            "region2",
+			ARN:               "rid2",
+			Tags:              map[string]string{"bye": "now"},
+		},
+	}
+
+	assertArrayEqualIgnoreOrder(t, expected, results)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestGetPrivateIPsAtTimeM1Schema(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	version := uint(4)
+	migrator := NewMockStorageMigrator(ctrl)
+	migrator.EXPECT().Version().Return(version, false, nil)
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+
+	thedb := &DB{
+		migrator: migrator,
+		sqldb:    mockdb,
+	}
+
+	at, _ := time.Parse(time.RFC3339, "2019-04-09T08:55:35+00:00")
+	ipAddress := "10.2.2.6"
+	rows := sqlmock.NewRows([]string{"aws_private_ip_assignment_private_ip",
+		"aws_resource_arn_id",
+		"aws_resource_meta",
+		"aws_region_region",
+		"aws_resource_type_resource_type",
+		"aws_account_account"}).AddRow("10.2.2.6",
+		"rid",
+		[]byte("{\"hi\":\"there1\"}"),
+		"region",
+		"type",
+		"aid")
+	mock.ExpectQuery("SELECT").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
+
+	results, err := thedb.FetchByIP(context.Background(), at, ipAddress)
+	if err != nil {
+		t.Errorf("error was not expected while saving resource: %s", err)
+	}
+
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, domain.CloudAssetDetails{
+		PrivateIPAddresses: []string{"10.2.2.6"},
+		ResourceType:       "type",
+		AccountID:          "aid",
+		Region:             "region",
+		ARN:                "rid",
+		Tags:               map[string]string{"hi": "there1"},
+	}, results[0])
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestGetPublicIPsAtTimeM1Schema(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	version := uint(4)
+	migrator := NewMockStorageMigrator(ctrl)
+	migrator.EXPECT().Version().Return(version, false, nil)
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+
+	thedb := &DB{
+		migrator: migrator,
+		sqldb:    mockdb,
+	}
+
+	at, _ := time.Parse(time.RFC3339, "2019-04-09T08:55:35+00:00")
+	ipAddress := "9.8.7.6"
+	rows := sqlmock.NewRows([]string{"aws_public_ip_assignment_public_ip",
+		"aws_public_ip_assignment_hostname",
+		"aws_resource_arn_id",
+		"aws_resource_meta",
+		"aws_region_region",
+		"aws_resource_type_resource_type",
+		"aws_account_account"}).AddRow("44.33.22.11",
+		"yahoo.com",
+		"rid",
+		[]byte("{\"hi\":\"there1\"}"),
+		"region",
+		"type",
+		"aid")
+	mock.ExpectQuery("SELECT").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
+
+	results, err := thedb.FetchByIP(context.Background(), at, ipAddress)
+	if err != nil {
+		t.Errorf("error was not expected while saving resource: %s", err)
+	}
+
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, domain.CloudAssetDetails{
+		PublicIPAddresses: []string{"44.33.22.11"},
+		Hostnames:         []string{"yahoo.com"},
+		ResourceType:      "type",
+		AccountID:         "aid",
+		Region:            "region",
+		ARN:               "rid",
+		Tags:              map[string]string{"hi": "there1"},
+	}, results[0])
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+func TestGetPrivateIPsAtTimeMultiRowsM1Schema(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	version := uint(4)
+	migrator := NewMockStorageMigrator(ctrl)
+	migrator.EXPECT().Version().Return(version, false, nil)
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+
+	thedb := &DB{
+		migrator: migrator,
+		sqldb:    mockdb,
+	}
+
+	at, _ := time.Parse(time.RFC3339, "2019-04-09T08:55:35+00:00")
+	ipAddress := "172.16.2.2"
+	rows := sqlmock.NewRows([]string{"aws_private_ip_assignment_private_ip",
+		"aws_resource_arn_id",
+		"aws_resource_meta",
+		"aws_region_region",
+		"aws_resource_type_resource_type",
+		"aws_account_account"}).AddRow("172.16.2.2",
+		"rid",
+		[]byte("{\"hi\":\"there1\"}"),
+		"region",
+		"type",
+		"aid").AddRow("172.16.3.3",
+		"rid2",
+		[]byte("{\"bye\":\"now\"}"),
+		"region2",
+		"type2",
+		"aid2")
+	mock.ExpectQuery("SELECT").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
+
+	results, err := thedb.FetchByIP(context.Background(), at, ipAddress)
+	if err != nil {
+		t.Errorf("error was not expected while saving resource: %s", err)
+	}
+
+	expected := []domain.CloudAssetDetails{
+		domain.CloudAssetDetails{
+			PrivateIPAddresses: []string{"172.16.2.2"},
+			ResourceType:       "type",
+			AccountID:          "aid",
+			Region:             "region",
+			ARN:                "rid",
+			Tags:               map[string]string{"hi": "there1"},
+		},
+		domain.CloudAssetDetails{
+			PrivateIPAddresses: []string{"172.16.3.3"},
+			ResourceType:       "type2",
+			AccountID:          "aid2",
+			Region:             "region2",
+			ARN:                "rid2",
+			Tags:               map[string]string{"bye": "now"},
+		},
+	}
+
+	assertArrayEqualIgnoreOrder(t, expected, results)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestGetPublicIPsAtTimeMultiRowsM1Schema(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	version := uint(4)
+	migrator := NewMockStorageMigrator(ctrl)
+	migrator.EXPECT().Version().Return(version, false, nil)
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+
+	thedb := &DB{
+		migrator: migrator,
+		sqldb:    mockdb,
+	}
+
+	at, _ := time.Parse(time.RFC3339, "2019-04-09T08:55:35+00:00")
+	ipAddress := "9.8.7.6"
+	rows := sqlmock.NewRows([]string{"aws_public_ip_assignment_public_ip",
+		"aws_public_ip_assignment_hostname",
+		"aws_resource_arn_id",
+		"aws_resource_meta",
+		"aws_region_region",
+		"aws_resource_type_resource_type",
+		"aws_account_account"}).AddRow("9.8.7.6",
+		"google.com",
+		"rid",
+		[]byte("{\"hi\":\"there\"}"),
+		"region",
+		"type",
+		"aid").AddRow("8.7.6.5",
+		"yahoo.com",
+		"rid2",
+		[]byte("{\"bye\":\"now\"}"),
+		"region2",
+		"type2",
+		"aid2")
+	mock.ExpectQuery("SELECT").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
+
+	results, err := thedb.FetchByIP(context.Background(), at, ipAddress)
+	if err != nil {
+		t.Errorf("error was not expected while saving resource: %s", err)
+	}
+
+	expected := []domain.CloudAssetDetails{
+		domain.CloudAssetDetails{
+			PublicIPAddresses: []string{"9.8.7.6"},
+			Hostnames:         []string{"google.com"},
+			ResourceType:      "type",
+			AccountID:         "aid",
+			Region:            "region",
+			ARN:               "rid",
+			Tags:              map[string]string{"hi": "there"},
+		},
+		domain.CloudAssetDetails{
+			PublicIPAddresses: []string{"8.7.6.5"},
+			Hostnames:         []string{"yahoo.com"},
 			ResourceType:      "type2",
 			AccountID:         "aid2",
 			Region:            "region2",

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -343,7 +343,7 @@ func TestGetPrivateIPsAtTimeM1Schema(t *testing.T) {
 		"region",
 		"type",
 		"aid")
-	mock.ExpectQuery("SELECT").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
+	mock.ExpectQuery("select").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
 
 	results, err := thedb.FetchByIP(context.Background(), at, ipAddress)
 	if err != nil {
@@ -397,7 +397,7 @@ func TestGetPublicIPsAtTimeM1Schema(t *testing.T) {
 		"region",
 		"type",
 		"aid")
-	mock.ExpectQuery("SELECT").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
+	mock.ExpectQuery("select").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
 
 	results, err := thedb.FetchByIP(context.Background(), at, ipAddress)
 	if err != nil {
@@ -454,7 +454,7 @@ func TestGetPrivateIPsAtTimeMultiRowsM1Schema(t *testing.T) {
 		"region2",
 		"type2",
 		"aid2")
-	mock.ExpectQuery("SELECT").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
+	mock.ExpectQuery("select").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
 
 	results, err := thedb.FetchByIP(context.Background(), at, ipAddress)
 	if err != nil {
@@ -525,7 +525,7 @@ func TestGetPublicIPsAtTimeMultiRowsM1Schema(t *testing.T) {
 		"region2",
 		"type2",
 		"aid2")
-	mock.ExpectQuery("SELECT").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
+	mock.ExpectQuery("select").WithArgs(ipAddress, at).WillReturnRows(rows).RowsWillBeClosed()
 
 	results, err := thedb.FetchByIP(context.Background(), at, ipAddress)
 	if err != nil {


### PR DESCRIPTION
"Find by Public IP" and "Find by Private IP" are combined into one pull request because the code change affects both. Summary of pull request:
- Add hostname as one of the return values in _resourceByPublicIPQuery_ query
- FetchByIP() function modified to work with old and new schema
- Add runFetchByIPQuery() to run queries, which are _resourceByPublicIPQuery_ and _resourceByPrivateIPQuery_ on new schema when called
- Add test cases 
 