### PR TITLE
Workaround for using closed connections

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -242,7 +242,10 @@ func (db *DB) GetSchemaVersion(ctx context.Context) (uint, error) {
 }
 
 func (db *DB) migrateSchema(ctx context.Context, d migrationDirection) (uint, error) {
-	var err error
+	err := db.sqldb.PingContext(ctx)
+	if err != nil {
+		return 0, err
+	}
 	switch d {
 	case up:
 		err = db.migrator.Steps(1)

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -1389,7 +1389,7 @@ func TestGetSchemaVersionErr(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	_, err = db.GetSchemaVersion(context.Background())
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.NotNil(t, err)
@@ -1405,7 +1405,7 @@ func TestGetSchemaVersionNil(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	v, err := db.GetSchemaVersion(context.Background())
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.Equal(t, uint(0), v)
@@ -1423,7 +1423,7 @@ func TestGetSchemaVersionSuccess(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	v, err := db.GetSchemaVersion(context.Background())
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.Equal(t, version, v)
@@ -1441,7 +1441,7 @@ func TestForceSchemaToVersionErr(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	err = db.ForceSchemaToVersion(context.Background(), version)
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.Error(t, err)
@@ -1458,7 +1458,7 @@ func TestForceSchemaToVersionSuccess(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	err = db.ForceSchemaToVersion(context.Background(), version)
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.Nil(t, err)
@@ -1475,7 +1475,7 @@ func TestMigrateSchemaToVersionErr(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	err = db.MigrateSchemaToVersion(context.Background(), version)
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.Error(t, err)
@@ -1492,7 +1492,7 @@ func TestMigrateSchemaToVersionSuccess(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	err = db.MigrateSchemaToVersion(context.Background(), version)
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.Nil(t, err)
@@ -1508,7 +1508,7 @@ func TestMigrateSchemaUpErr(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	_, err = db.MigrateSchemaUp(context.Background())
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.Error(t, err)
@@ -1526,7 +1526,7 @@ func TestMigrateSchemaUpSuccess(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	v, err := db.MigrateSchemaUp(context.Background())
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.NoError(t, err)
@@ -1543,7 +1543,7 @@ func TestMigrateSchemaDownErr(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	_, err = db.MigrateSchemaDown(context.Background())
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.Error(t, err)
@@ -1561,7 +1561,7 @@ func TestMigrateSchemaDownSuccess(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer mockdb.Close()
-	db := &DB{migrator: migrator, sqldb: mockdb }
+	db := &DB{migrator: migrator, sqldb: mockdb}
 	v, err := db.MigrateSchemaDown(context.Background())
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.NoError(t, err)

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -1384,8 +1384,14 @@ func TestGetSchemaVersionErr(t *testing.T) {
 	defer ctrl.Finish()
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Version().Return(uint(0), false, errors.New("something went wrong"))
-	db := &DB{migrator: migrator}
-	_, err := db.GetSchemaVersion(context.Background())
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
+	_, err = db.GetSchemaVersion(context.Background())
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.NotNil(t, err)
 }
 
@@ -1394,8 +1400,14 @@ func TestGetSchemaVersionNil(t *testing.T) {
 	defer ctrl.Finish()
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Version().Return(uint(0), false, migrate.ErrNilVersion)
-	db := &DB{migrator: migrator}
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
 	v, err := db.GetSchemaVersion(context.Background())
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.Equal(t, uint(0), v)
 	require.Nil(t, err)
 }
@@ -1406,8 +1418,14 @@ func TestGetSchemaVersionSuccess(t *testing.T) {
 	version := uint(rand.Uint64())
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Version().Return(version, false, nil)
-	db := &DB{migrator: migrator}
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
 	v, err := db.GetSchemaVersion(context.Background())
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.Equal(t, version, v)
 	require.Nil(t, err)
 }
@@ -1418,8 +1436,14 @@ func TestForceSchemaToVersionErr(t *testing.T) {
 	version := uint(rand.Uint64())
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Force(int(version)).Return(errors.New("something happened"))
-	db := &DB{migrator: migrator}
-	err := db.ForceSchemaToVersion(context.Background(), version)
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
+	err = db.ForceSchemaToVersion(context.Background(), version)
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.Error(t, err)
 }
 
@@ -1429,8 +1453,14 @@ func TestForceSchemaToVersionSuccess(t *testing.T) {
 	version := uint(rand.Uint64())
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Force(int(version)).Return(nil)
-	db := &DB{migrator: migrator}
-	err := db.ForceSchemaToVersion(context.Background(), version)
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
+	err = db.ForceSchemaToVersion(context.Background(), version)
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.Nil(t, err)
 }
 
@@ -1440,8 +1470,14 @@ func TestMigrateSchemaToVersionErr(t *testing.T) {
 	version := uint(rand.Uint64())
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Migrate(version).Return(errors.New("something happened"))
-	db := &DB{migrator: migrator}
-	err := db.MigrateSchemaToVersion(context.Background(), version)
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
+	err = db.MigrateSchemaToVersion(context.Background(), version)
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.Error(t, err)
 }
 
@@ -1451,8 +1487,14 @@ func TestMigrateSchemaToVersionSuccess(t *testing.T) {
 	version := uint(rand.Uint64())
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Migrate(version).Return(nil)
-	db := &DB{migrator: migrator}
-	err := db.MigrateSchemaToVersion(context.Background(), version)
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
+	err = db.MigrateSchemaToVersion(context.Background(), version)
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.Nil(t, err)
 }
 
@@ -1461,8 +1503,14 @@ func TestMigrateSchemaUpErr(t *testing.T) {
 	defer ctrl.Finish()
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Steps(gomock.Any()).Return(errors.New("something happened"))
-	db := &DB{migrator: migrator}
-	_, err := db.MigrateSchemaUp(context.Background())
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
+	_, err = db.MigrateSchemaUp(context.Background())
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.Error(t, err)
 }
 
@@ -1473,8 +1521,14 @@ func TestMigrateSchemaUpSuccess(t *testing.T) {
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Steps(gomock.Any()).Return(nil)
 	migrator.EXPECT().Version().Return(version, false, nil) //Version() (version uint, dirty bool, err error)
-	db := &DB{migrator: migrator}
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
 	v, err := db.MigrateSchemaUp(context.Background())
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.NoError(t, err)
 	require.Equal(t, version, v)
 }
@@ -1484,8 +1538,14 @@ func TestMigrateSchemaDownErr(t *testing.T) {
 	defer ctrl.Finish()
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Steps(gomock.Any()).Return(errors.New("something happened"))
-	db := &DB{migrator: migrator}
-	_, err := db.MigrateSchemaDown(context.Background())
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
+	_, err = db.MigrateSchemaDown(context.Background())
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.Error(t, err)
 }
 
@@ -1496,8 +1556,14 @@ func TestMigrateSchemaDownSuccess(t *testing.T) {
 	migrator := NewMockStorageMigrator(ctrl)
 	migrator.EXPECT().Steps(gomock.Any()).Return(nil)
 	migrator.EXPECT().Version().Return(version, false, nil) //Version() (version uint, dirty bool, err error)
-	db := &DB{migrator: migrator}
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+	db := &DB{migrator: migrator, sqldb: mockdb }
 	v, err := db.MigrateSchemaDown(context.Background())
+	require.NoError(t, mock.ExpectationsWereMet())
 	require.NoError(t, err)
 	require.Equal(t, version, v)
 }


### PR DESCRIPTION
The schema management code uses postgres driver directly w/o golang sql wrapper, so it does not have reconnect logic that is present in go sql by default:
https://github.com/golang/go/blob/master/src/database/sql/sql.go#L784
Adding PingContext should re-initialize connection if it is in bad state before any schema related queries are run.
