### PR TITLE
Adding champions to account owners

### DIFF
--- a/db-migrations/000005_adding_owners.down.sql
+++ b/db-migrations/000005_adding_owners.down.sql
@@ -1,3 +1,8 @@
 -- roll-back of schema changes for account owners and champions
 BEGIN;
+
+DROP TABLE IF EXISTS person;
+DROP TABLE IF EXISTS account_champion;
+DROP TABLE IF EXISTS account_owner;
+
 COMMIT;

--- a/db-migrations/000005_adding_owners.down.sql
+++ b/db-migrations/000005_adding_owners.down.sql
@@ -1,0 +1,3 @@
+-- roll-back of schema changes for account owners and champions
+BEGIN;
+COMMIT;

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -10,15 +10,19 @@ create table person(
 );
 
 create table account_champion(
+    person_id serial,
+    aws_account_id integer,
     foreign key(person_id) references person (id),
     foreign key(aws_account_id) references aws_account (id),
-    constraint account_champ_unique unique(person_id, aws_account_id)
+    unique(person_id, aws_account_id)
 );
 
 create table account_owner(
+    person_id serial,
+    aws_account_id integer,
     foreign key(person_id) references person (id),
     foreign key(aws_account_id) references aws_account (id),
-    constraint account_unique unique (aws_account_id)
+    unique (aws_account_id)
 );
 
 COMMIT;

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -5,9 +5,14 @@ create table champions(
     champion varchar not null
 )
 
+create table owners(
+    id serial primary key,
+    owner varchar not null,
+    foreign key(aws_account_id) references aws_account (id)
+)
+
 alter table aws_account
 -- accounts may or may not have champions associated with them, so we may not need to enforce a foreign key restraint
 add column champion_id serial null unique
-add column owner varchar unique
 
 COMMIT;

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -8,5 +8,6 @@ create table champions(
 alter table aws_account
 -- accounts may or may not have champions associated with them, so we may not need to enforce a foreign key restraint
 add column champion_id serial null unique
+add column owner varchar unique
 
 COMMIT;

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -1,0 +1,3 @@
+-- schema changes for account owners and champions
+BEGIN;
+COMMIT;

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -2,7 +2,7 @@
 BEGIN;
 create table champions(
     id serial primary key,
-    champion varchar not null,
+    champion varchar not null
 )
 
 alter table aws_account

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -10,13 +10,13 @@ create table person(
 );
 
 create table account_champion(
-    foreign key(people_id) references person (id),
+    foreign key(person_id) references person (id),
     foreign key(aws_account_id) references aws_account (id),
-    constraint account_champ_unique unique(people_id, aws_account_id)
+    constraint account_champ_unique unique(person_id, aws_account_id)
 );
 
 create table account_owner(
-    foreign key(people_id) references person (id),
+    foreign key(person_id) references person (id),
     foreign key(aws_account_id) references aws_account (id),
     constraint account_unique unique (aws_account_id)
 );

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -7,17 +7,18 @@ create table person(
     email varchar unique not null,
     name varchar not null,
     valid boolean not null
-)
+);
 
-create table champions(
+create table account_champion(
     foreign key(people_id) references person (id),
     foreign key(aws_account_id) references aws_account (id),
-    constraint champ_unique unique(people_id, aws_account_id)
-)
+    constraint account_champ_unique unique(people_id, aws_account_id)
+);
 
-create table aws_accounts_owners(
+create table account_owner(
     foreign key(people_id) references person (id),
-    foreign key(aws_account_id) references aws_account (id) unique
-)
+    foreign key(aws_account_id) references aws_account (id),
+    constraint account_unique unique (aws_account_id)
+);
 
 COMMIT;

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -1,18 +1,22 @@
 -- schema changes for account owners and champions
 BEGIN;
-create table champions(
+
+create table person(
     id serial primary key,
-    champion varchar not null
+    login varchar not null,
+    email varchar not null,
+    name varchar not null,
+    valid boolean
 )
 
-create table owners(
-    id serial primary key,
-    owner varchar not null,
+create table champions(
+    foreign key(people_id) references person (id),
     foreign key(aws_account_id) references aws_account (id)
 )
 
-alter table aws_account
--- accounts may or may not have champions associated with them, so we may not need to enforce a foreign key restraint
-add column champion_id serial null unique
+create table owner(
+    foreign key(people_id) references person (id),
+    foreign key(aws_account_id) references aws_account (id)
+)
 
 COMMIT;

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -7,6 +7,6 @@ create table champions(
 
 alter table aws_account
 -- accounts may or may not have champions associated with them, so we may not need to enforce a foreign key restraint
-add column champion_id null unique
+add column champion_id serial null unique
 
 COMMIT;

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -11,7 +11,8 @@ create table person(
 
 create table champions(
     foreign key(people_id) references person (id),
-    foreign key(aws_account_id) references aws_account (id)
+    foreign key(aws_account_id) references aws_account (id),
+    constraint champ_unique unique(people_id, aws_account_id)
 )
 
 create table aws_accounts_owners(

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -1,3 +1,12 @@
 -- schema changes for account owners and champions
 BEGIN;
+create table champions(
+    id serial primary key,
+    champion varchar not null,
+)
+
+alter table aws_account
+-- accounts may or may not have champions associated with them, so we may not need to enforce a foreign key restraint
+add column champion_id null unique
+
 COMMIT;

--- a/db-migrations/000005_adding_owners.up.sql
+++ b/db-migrations/000005_adding_owners.up.sql
@@ -3,10 +3,10 @@ BEGIN;
 
 create table person(
     id serial primary key,
-    login varchar not null,
-    email varchar not null,
+    login varchar unique not null,
+    email varchar unique not null,
     name varchar not null,
-    valid boolean
+    valid boolean not null
 )
 
 create table champions(
@@ -14,9 +14,9 @@ create table champions(
     foreign key(aws_account_id) references aws_account (id)
 )
 
-create table owner(
+create table aws_accounts_owners(
     foreign key(people_id) references person (id),
-    foreign key(aws_account_id) references aws_account (id)
+    foreign key(aws_account_id) references aws_account (id) unique
 )
 
 COMMIT;


### PR DESCRIPTION
We are modifying the database to satisfy the following constraints:
```
Every account has only one owner

Every account has one or more champions

Any of champions can be null (but should not)
```

**TODO:**
- [x] add table for keeping track of account owners.
- [x] add unique constraints to person table
- [x] test create queries work when run during a migration
- [x] task: add indexes, at least for the fields that will be queried frequently
- [x] test manually