### PR TITLE
Stopgap script to unblock work depending on resources export for point in time

### DIFF
--- a/bulk-export/README.md
+++ b/bulk-export/README.md
@@ -1,0 +1,31 @@
+# Bulk export of resource assignments for point in time
+## Summary
+The [shell script](export.sh) and [SQL file](export.sql) allow to export all the resources 
+and assignments for the specified timestamp utilizing new database schema.
+
+The export runs manually via command line using connection to the Postgres database. 
+This is a __STOPGAP__ solution until the bulk export endpoint `/v1/cloud/asset` is updated to use the new SQL schema.
+
+The resulting JSON dump file has the format identical to the one defined in `#/components/schemas/BulkCloudAssets` in the 
+[API description](../api.yaml)
+
+## Using it
+### Pre-requisites
+* PSQL command line client
+* `jq` utility
+* Read access to Asset Inventory database or replica
+
+### Caveats
+* As this is a stopgap, the query performance is not most optimal (no indices for several things), json conversion on SQL server side takes tons of CPU/RAM.
+* Please test in controlled environment before running this in production. Consider using separate disconnected replica.
+* JSON wrangling via `jq` could definitely benefit by replacement with better validation and error handling. 
+
+### Performance 
+Around 4 seconds per page of 3K results with RDS, output ~14Mb of JSON. Definitely YMMV.
+
+### Execution steps
+* Set the standard PostgreSQL connection environment variables to access the DB.
+* Change the `snapshot_timestamp` in the [export script](export.sh) (NB - nested quoting is required).
+* Run the script. It prints a dot '.' after processing each page of results.
+* When export completes, the name of resulting dump will be printed
+

--- a/bulk-export/export.sh
+++ b/bulk-export/export.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+PAGE_SIZE=3000
+LAST_ID=0
+PREFIX=$$
+while :
+do
+  OUTPUT=export-${PREFIX}-${LAST_ID}.json
+  # the nested quotes are required, as the first pair (doubles) is "eaten" by the shell
+  psql -t  \
+    -v snapshot_timestamp="'2020-05-05 00:00:00.000'" \
+    -v id_offset=${LAST_ID}  \
+    -v page_size=${PAGE_SIZE} < export.sql > ${OUTPUT}
+  COUNT=$(jq '.|length' < ${OUTPUT})
+  if [ "${COUNT}" -ne "${PAGE_SIZE}" ]; # we got the last page
+  then
+    break
+  fi
+  LAST_ID=$(jq '.[-1].id'< ${OUTPUT})
+  echo "."
+done
+echo "."
+# combine the arrays -s, add, remove id as it is not part of schema
+jq -s 'add|del(.[].id)' export-${PREFIX}-*.json > export-${PREFIX}.json
+rm export-${PREFIX}-*.json
+echo export-${PREFIX}.json

--- a/bulk-export/export.sql
+++ b/bulk-export/export.sql
@@ -1,0 +1,45 @@
+select array_to_json(
+               array_agg(
+                       row_to_json(res_assigned_joined)
+                   )
+           )
+from (
+         select res_assigned.id,
+                res_assigned.arn,
+                res_assigned.private_ips,
+                res_assigned.public_ips,
+                res_assigned.hostnames,
+                aws_account.account,
+                aws_region.region,
+                aws_resource_type.resource_type,
+                res_assigned.metadata
+         from (select ar.id                            as id,
+                      ar.arn_id                        as arn,
+                      ar.meta                          as metadata,
+                      ar.aws_account_id                as account_id,
+                      ar.aws_region_id                 as region_id,
+                      ar.aws_resource_type_id          as type_id,
+                      array_agg(distinct private_ip)   as private_ips,
+                      array_agg(distinct public_ip)    as public_ips,
+                      array_agg(distinct aws_hostname) as hostnames
+               from aws_resource ar
+                        left join aws_private_ip_assignment pri
+                                  on
+                                      ar.id = pri.aws_resource_id
+                        left join aws_public_ip_assignment pub
+                                  on
+                                      ar.id = pub.aws_resource_id
+               where ar.id > :id_offset
+                 and pri.not_before < :snapshot_timestamp
+                 and (pri.not_after is null or pri.not_after > :snapshot_timestamp)
+                 and pub.not_before < :snapshot_timestamp
+                 and (pub.not_after is null or pub.not_after > :snapshot_timestamp)
+               group by ar.id
+               order by ar.id
+               limit :page_size
+              ) res_assigned
+                  left join aws_account on res_assigned.account_id = aws_account.id
+                  left join aws_region on res_assigned.region_id = aws_region.id
+                  left join aws_resource_type on res_assigned.type_id = aws_resource_type.id
+     ) res_assigned_joined;
+

--- a/bulk-export/export.sql
+++ b/bulk-export/export.sql
@@ -1,3 +1,16 @@
+/*
+JSON spec:
+type CloudAssetDetails struct {
+	PrivateIPAddresses []string          `json:"privateIpAddresses"`
+	PublicIPAddresses  []string          `json:"publicIpAddresses"`
+	Hostnames          []string          `json:"hostnames"`
+	ResourceType       string            `json:"resourceType"`
+	AccountID          string            `json:"accountId"`
+	Region             string            `json:"region"`
+	ARN                string            `json:"arn"`
+	Tags               map[string]string `json:"tags"`
+}
+*/
 select array_to_json(
                array_agg(
                        row_to_json(res_assigned_joined)
@@ -6,12 +19,12 @@ select array_to_json(
 from (
          select res_assigned.id,
                 res_assigned.arn,
-                res_assigned.private_ips,
-                res_assigned.public_ips,
+                res_assigned.private_ips as privateIpAddresses,
+                res_assigned.public_ips as publicIpAddresses,
                 res_assigned.hostnames,
-                aws_account.account,
+                aws_account.account as accountId,
                 aws_region.region,
-                aws_resource_type.resource_type,
+                aws_resource_type.resource_type as resourceType,
                 res_assigned.metadata
          from (select ar.id                            as id,
                       ar.arn_id                        as arn,


### PR DESCRIPTION
**Caveat: this is not the code I am most proud of. It solves the problem of bulk export with new schema that is a blocker right now, and which we can not implement properly due to conflicting priorities. The expectation is for "proper" bulk export API with new schema to be implemented later.**

The script talks directly to the Postgres DB (ideally - replica). All JSON serialization is done on Postgres side. Some local wrangling with `jq` to combine results.

Output is designed to be 100% compatible with output of API endpoint described in api.yaml, so any existing code to parse the data can be re-used.

I was able to run this with staging DB instance that has large amount of data, and it produces valid JSON that has the number of entries matching the count of active resources for point in time in the database.