### PR TITLE
Fix docker permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN zip -r -0 /zoneinfo.zip .
 ###################################
 
 FROM scratch
-COPY --from=BUILDER /opt/app .
+COPY --chown=root:root --from=BUILDER /opt/app .
 # the timezone data:
-COPY --from=CERTS /zoneinfo.zip /
+COPY --chown=root:root --from=CERTS /zoneinfo.zip /
 # the tls certificates:
-COPY --from=CERTS /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY db-migrations /db-migrations
+COPY --chown=root:root --from=CERTS /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --chown=root:root db-migrations /db-migrations
 
 ENV ZONEINFO /zoneinfo.zip
 ENTRYPOINT ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN zip -r -0 /zoneinfo.zip .
 ###################################
 
 FROM scratch
-COPY --chown=root:root --from=BUILDER /opt/app .
+COPY --chown=0:0 --from=BUILDER /opt/app .
 # the timezone data:
-COPY --chown=root:root --from=CERTS /zoneinfo.zip /
+COPY --chown=0:0 --from=CERTS /zoneinfo.zip /
 # the tls certificates:
-COPY --chown=root:root --from=CERTS /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --chown=root:root db-migrations /db-migrations
+COPY --chown=0:0 --from=CERTS /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --chown=0:0 db-migrations /db-migrations
 
 ENV ZONEINFO /zoneinfo.zip
 ENTRYPOINT ["/app"]


### PR DESCRIPTION
We have to use numeric `uid` and `gid` as the container does not have `/etc/passwd` file, so docker "refuses" to use string names during build.
0 is uid/gid  used for root.