### PR TITLE
changed metadata to tags for json consistency

### DIFF
--- a/bulk-export/export.sql
+++ b/bulk-export/export.sql
@@ -28,7 +28,7 @@ from (
                 res_assigned.metadata
          from (select ar.id                            as id,
                       ar.arn_id                        as arn,
-                      ar.meta                          as metadata,
+                      ar.meta                          as tags,
                       ar.aws_account_id                as account_id,
                       ar.aws_region_id                 as region_id,
                       ar.aws_resource_type_id          as type_id,

--- a/bulk-export/export.sql
+++ b/bulk-export/export.sql
@@ -25,7 +25,7 @@ from (
                 aws_account.account as accountId,
                 aws_region.region,
                 aws_resource_type.resource_type as resourceType,
-                res_assigned.metadata
+                res_assigned.tags
          from (select ar.id                            as id,
                       ar.arn_id                        as arn,
                       ar.meta                          as tags,


### PR DESCRIPTION
This allows the resulting bulk-export json to reflect a CloudAssetDetail struct 

```type CloudAssetDetails struct {
	PrivateIPAddresses []string          `json:"privateIpAddresses"`
	PublicIPAddresses  []string          `json:"publicIpAddresses"`
	Hostnames          []string          `json:"hostnames"`
	ResourceType       string            `json:"resourceType"`
	AccountID          string            `json:"accountId"`
	Region             string            `json:"region"`
	ARN                string            `json:"arn"`
	Tags               map[string]string `json:"tags"`
}```