### PR TITLE
Fix invalid result for empty lookup

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -894,8 +894,9 @@ func (db *DB) FetchByARNID(ctx context.Context, when time.Time, arnID string) ([
 	var asset domain.CloudAssetDetails
 	var accountID int
 	hasTag := false
+	empty := true
 	for rows.Next() {
-
+		empty = false // there is no way to check for size of SQL resul tset in golang
 		var privateIPAddress sql.NullString
 		var publicIPAddress sql.NullString
 		var hostname sql.NullString
@@ -924,6 +925,10 @@ func (db *DB) FetchByARNID(ctx context.Context, when time.Time, arnID string) ([
 	rows.Close()
 	if err = rows.Err(); err != nil {
 		return nil, err
+	}
+
+	if empty { // we got 0 rows, nothing to process
+		return cloudAssetDetails, nil
 	}
 
 	for ip := range tempPrivateIPMap {

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -896,7 +896,7 @@ func (db *DB) FetchByARNID(ctx context.Context, when time.Time, arnID string) ([
 	hasTag := false
 	empty := true
 	for rows.Next() {
-		empty = false // there is no way to check for size of SQL resul tset in golang
+		empty = false // there is no way to check for size of SQL result set in golang
 		var privateIPAddress sql.NullString
 		var publicIPAddress sql.NullString
 		var hostname sql.NullString

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -1079,6 +1079,38 @@ func TestGetHostnamesAtTimeMultiRowsSchema2(t *testing.T) {
 	}
 }
 
+func TestGetByARNIDEmpty(t *testing.T) {
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+
+	thedb := DB{
+		sqldb: mockdb,
+	}
+
+	withSchemaVersion(4, mock)
+	at, _ := time.Parse(time.RFC3339, "2019-04-09T08:55:35+00:00")
+	const arnID = "arnid"
+	rows := sqlmock.NewRows([]string{"aws_private_ip_assignment_private_ip",
+		"aws_public_ip_assignment_public_ip",
+		"aws_public_ip_assignment_aws_hostname",
+		"aws_resource_type_resource_type",
+		"aws_account_account",
+		"aws_region_region",
+		"aws_resource_meta",
+		"aws_resource_aws_account_id",
+	})
+
+	mock.ExpectQuery("select").WithArgs(arnID, at).WillReturnRows(rows).RowsWillBeClosed()
+	results, err := thedb.FetchByARNID(context.Background(), at, arnID)
+	if err != nil {
+		t.Errorf("error was not expected during lookup: %s", err)
+	}
+	assert.Equal(t, 0, len(results))
+}
+
 func TestGetARNIDAtTime(t *testing.T) {
 	mockdb, mock, err := sqlmock.New()
 	if err != nil {


### PR DESCRIPTION
The code before this change used to return JSON with all fields but ARN ID empty for cases when non-existent ARN was passed. Fixed to return 404 instead.