### PR TITLE
Report the state of database schema for GET version

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -468,11 +468,11 @@ paths:
       description: "Allows to discover the current state of database schema for the specific deployment"
       responses:
         200:
-          description: "Schema Version"
+          description: "Schema State"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SchemaVersion"
+                $ref: "#/components/schemas/SchemaState"
       x-transportd:
         backend: app
         enabled:
@@ -811,6 +811,13 @@ components:
       properties:
         version:
           type: integer
+    SchemaState:
+      type: object
+      properties:
+        version:
+          type: integer
+        dirty:
+          type: boolean
     AccountOwner:
       type: object
       properties:

--- a/main.go
+++ b/main.go
@@ -53,11 +53,11 @@ func (c *component) New(ctx context.Context, conf *config) (func(context.Context
 	if err != nil {
 		return nil, err
 	}
-	ver, err := schemaManager.GetSchemaVersion(context.Background())
+	ver, dirty, err := schemaManager.GetSchemaVersion(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	if ver < conf.PostgresConfig.MinSchemaVersion {
+	if !dirty && ver < conf.PostgresConfig.MinSchemaVersion { // do not touch schema if it is dirty
 		// ErrNoChange means we are already on required version so we are good
 		err := schemaManager.MigrateSchemaToVersion(context.Background(), conf.PostgresConfig.MinSchemaVersion)
 		if err != nil && err != migrate.ErrNoChange {

--- a/pkg/domain/storage_schema.go
+++ b/pkg/domain/storage_schema.go
@@ -12,7 +12,7 @@ type StorageSchemaMigrator interface {
 
 // SchemaVersionGetter is used to retrieve the current version of DB schema
 type SchemaVersionGetter interface {
-	GetSchemaVersion(ctx context.Context) (uint, error)
+	GetSchemaVersion(ctx context.Context) (uint, bool, error)
 }
 
 // SchemaVersionForcer is used to force set database schema to specific version after failed migration

--- a/pkg/handlers/v1/force_schema.go
+++ b/pkg/handlers/v1/force_schema.go
@@ -13,7 +13,6 @@ type ForceSchemaHandler struct {
 	SchemaVersionForcer domain.SchemaVersionForcer
 }
 
-
 // SchemaVersion represents a database schema version
 type SchemaVersion struct {
 	Version uint `json:"version"`

--- a/pkg/handlers/v1/force_schema.go
+++ b/pkg/handlers/v1/force_schema.go
@@ -13,6 +13,12 @@ type ForceSchemaHandler struct {
 	SchemaVersionForcer domain.SchemaVersionForcer
 }
 
+
+// SchemaVersion represents a database schema version
+type SchemaVersion struct {
+	Version uint `json:"version"`
+}
+
 // Handle handles the call to force database schema version after failed migration
 func (h *ForceSchemaHandler) Handle(ctx context.Context, input SchemaVersion) error {
 	logger := h.LogFn(ctx)

--- a/pkg/handlers/v1/get_schema_version.go
+++ b/pkg/handlers/v1/get_schema_version.go
@@ -7,11 +7,10 @@ import (
 	"github.com/asecurityteam/asset-inventory-api/pkg/logs"
 )
 
-
 // SchemaState represents current database schema version and state
 type SchemaState struct {
 	Version uint `json:"version"`
-	Dirty bool `json:"dirty"`
+	Dirty   bool `json:"dirty"`
 }
 
 // GetSchemaVersionHandler handles requests for getting the currently active database schema version
@@ -29,6 +28,6 @@ func (h *GetSchemaVersionHandler) Handle(ctx context.Context) (SchemaState, erro
 	}
 	return SchemaState{
 		Version: currentVersion,
-		Dirty: dirty,
+		Dirty:   dirty,
 	}, nil
 }

--- a/pkg/handlers/v1/get_schema_version.go
+++ b/pkg/handlers/v1/get_schema_version.go
@@ -7,9 +7,11 @@ import (
 	"github.com/asecurityteam/asset-inventory-api/pkg/logs"
 )
 
-// SchemaVersion represents an active database schema version
-type SchemaVersion struct {
+
+// SchemaState represents current database schema version and state
+type SchemaState struct {
 	Version uint `json:"version"`
+	Dirty bool `json:"dirty"`
 }
 
 // GetSchemaVersionHandler handles requests for getting the currently active database schema version
@@ -19,13 +21,14 @@ type GetSchemaVersionHandler struct {
 }
 
 // Handle handles the request for schema version
-func (h *GetSchemaVersionHandler) Handle(ctx context.Context) (SchemaVersion, error) {
-	currentVersion, err := h.Getter.GetSchemaVersion(ctx)
+func (h *GetSchemaVersionHandler) Handle(ctx context.Context) (SchemaState, error) {
+	currentVersion, dirty, err := h.Getter.GetSchemaVersion(ctx)
 	if err != nil {
 		h.LogFn(ctx).Error(logs.StorageError{Reason: err.Error()})
-		return SchemaVersion{}, err
+		return SchemaState{}, err
 	}
-	return SchemaVersion{
+	return SchemaState{
 		Version: currentVersion,
+		Dirty: dirty,
 	}, nil
 }

--- a/pkg/handlers/v1/get_schema_version_test.go
+++ b/pkg/handlers/v1/get_schema_version_test.go
@@ -15,7 +15,7 @@ func TestGetSchemaVersionError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockGetter := NewMockSchemaVersionGetter(ctrl)
-	mockGetter.EXPECT().GetSchemaVersion(gomock.Any()).Return(uint(0), errors.New(""))
+	mockGetter.EXPECT().GetSchemaVersion(gomock.Any()).Return(uint(0), false, errors.New(""))
 
 	handler := GetSchemaVersionHandler{
 		LogFn:  testLogFn,
@@ -33,7 +33,7 @@ func TestGetSchemaVersion(t *testing.T) {
 	v := uint(rand.Uint32() + 1) // version number to use for test
 
 	mockGetter := NewMockSchemaVersionGetter(ctrl)
-	mockGetter.EXPECT().GetSchemaVersion(gomock.Any()).Return(v, nil)
+	mockGetter.EXPECT().GetSchemaVersion(gomock.Any()).Return(v, false, nil)
 
 	handler := GetSchemaVersionHandler{
 		LogFn:  testLogFn,
@@ -43,4 +43,5 @@ func TestGetSchemaVersion(t *testing.T) {
 	res, err := handler.Handle(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, v, res.Version)
+	assert.Equal(t, false, res.Dirty)
 }

--- a/pkg/handlers/v1/mock_storage_test.go
+++ b/pkg/handlers/v1/mock_storage_test.go
@@ -6,10 +6,12 @@ package v1
 
 import (
 	context "context"
-	domain "github.com/asecurityteam/asset-inventory-api/pkg/domain"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+
+	domain "github.com/asecurityteam/asset-inventory-api/pkg/domain"
 )
 
 // MockPartitionGenerator is a mock of PartitionGenerator interface

--- a/pkg/handlers/v1/mock_storage_test.go
+++ b/pkg/handlers/v1/mock_storage_test.go
@@ -413,12 +413,13 @@ func (m *MockSchemaVersionGetter) EXPECT() *MockSchemaVersionGetterMockRecorder 
 }
 
 // GetSchemaVersion mocks base method
-func (m *MockSchemaVersionGetter) GetSchemaVersion(arg0 context.Context) (uint, error) {
+func (m *MockSchemaVersionGetter) GetSchemaVersion(arg0 context.Context) (uint, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSchemaVersion", arg0)
 	ret0, _ := ret[0].(uint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetSchemaVersion indicates an expected call of GetSchemaVersion

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -112,7 +112,7 @@ func (sm *SchemaManager) migrateSchema(ctx context.Context, d migrationDirection
 	if err != nil {
 		return 0, err
 	}
-	version, _ , err := sm.GetSchemaVersion(ctx)
+	version, _, err := sm.GetSchemaVersion(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -80,20 +80,20 @@ func (sm *SchemaManager) MigrateSchemaToVersion(ctx context.Context, version uin
 }
 
 // GetSchemaVersion retrieves the current version of database schema
-func (sm *SchemaManager) GetSchemaVersion(ctx context.Context) (uint, error) {
+func (sm *SchemaManager) GetSchemaVersion(ctx context.Context) (uint, bool, error) {
 	err := sm.EnsureConnected()
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
-	v, _, err := sm.migrator.Version()
+	v, dirty, err := sm.migrator.Version()
 	if err == migrate.ErrNilVersion {
 		// special handling for the version not being present
-		return 0, nil
+		return 0, dirty, nil
 	}
 	if err != nil {
-		return 0, err
+		return 0, dirty, err
 	}
-	return v, nil
+	return v, dirty, nil
 }
 
 func (sm *SchemaManager) migrateSchema(ctx context.Context, d migrationDirection) (uint, error) {
@@ -112,7 +112,7 @@ func (sm *SchemaManager) migrateSchema(ctx context.Context, d migrationDirection
 	if err != nil {
 		return 0, err
 	}
-	version, err := sm.GetSchemaVersion(ctx)
+	version, _ , err := sm.GetSchemaVersion(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/schema_test.go
+++ b/pkg/storage/schema_test.go
@@ -17,7 +17,7 @@ func TestGetSchemaVersionErr(t *testing.T) {
 	migrator := NewMockStorageSchemaMigrator(ctrl)
 	migrator.EXPECT().Version().Return(uint(0), false, errors.New("something went wrong"))
 	sm := &SchemaManager{migrator: migrator}
-	_, _ , err := sm.GetSchemaVersion(context.Background())
+	_, _, err := sm.GetSchemaVersion(context.Background())
 	require.Error(t, err)
 }
 
@@ -28,7 +28,7 @@ func TestGetSchemaVersionNil(t *testing.T) {
 	migrator.EXPECT().Version().Return(uint(0), false, migrate.ErrNilVersion)
 	migrator.EXPECT().Version().Return(uint(0), false, migrate.ErrNilVersion)
 	sm := &SchemaManager{migrator: migrator}
-	v, dirty,  err := sm.GetSchemaVersion(context.Background())
+	v, dirty, err := sm.GetSchemaVersion(context.Background())
 	require.Equal(t, uint(0), v)
 	require.Equal(t, false, dirty)
 	require.Nil(t, err)

--- a/pkg/storage/schema_test.go
+++ b/pkg/storage/schema_test.go
@@ -17,7 +17,7 @@ func TestGetSchemaVersionErr(t *testing.T) {
 	migrator := NewMockStorageSchemaMigrator(ctrl)
 	migrator.EXPECT().Version().Return(uint(0), false, errors.New("something went wrong"))
 	sm := &SchemaManager{migrator: migrator}
-	_, err := sm.GetSchemaVersion(context.Background())
+	_, _ , err := sm.GetSchemaVersion(context.Background())
 	require.Error(t, err)
 }
 
@@ -28,8 +28,9 @@ func TestGetSchemaVersionNil(t *testing.T) {
 	migrator.EXPECT().Version().Return(uint(0), false, migrate.ErrNilVersion)
 	migrator.EXPECT().Version().Return(uint(0), false, migrate.ErrNilVersion)
 	sm := &SchemaManager{migrator: migrator}
-	v, err := sm.GetSchemaVersion(context.Background())
+	v, dirty,  err := sm.GetSchemaVersion(context.Background())
 	require.Equal(t, uint(0), v)
+	require.Equal(t, false, dirty)
 	require.Nil(t, err)
 }
 
@@ -41,8 +42,9 @@ func TestGetSchemaVersionSuccess(t *testing.T) {
 	migrator.EXPECT().Version().Return(version, false, nil)
 	migrator.EXPECT().Version().Return(version, false, nil)
 	sm := &SchemaManager{migrator: migrator}
-	v, err := sm.GetSchemaVersion(context.Background())
+	v, dirty, err := sm.GetSchemaVersion(context.Background())
 	require.Equal(t, version, v)
+	require.Equal(t, false, dirty)
 	require.Nil(t, err)
 }
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -560,7 +560,10 @@ func TestDeleteNotFoundPartition(t *testing.T) {
 // before is the function all tests should call to ensure no state is carried over
 // from prior tests
 func before(t *testing.T, db *storage.DB, sm *storage.SchemaManager) {
-	v, err := sm.GetSchemaVersion(context.Background())
+	v, dirty, err := sm.GetSchemaVersion(context.Background())
+	if dirty {
+		t.Fatalf("schema is marked dirty, refusing to proceed")
+	}
 	if err != nil { //the migrations mechanism was not initialized yet
 		require.NoError(t, sm.MigrateSchemaToVersion(context.Background(), testWithSchemaVersion))
 		v = testWithSchemaVersion


### PR DESCRIPTION
Introduce additional field in response for GET version that tells if the database schema is in "dirty" state after a failed migration.