### PR TITLE
Fix the issue with failed migrations "poisoning" the db connection for susequent migrations

### DIFF
--- a/pkg/domain/storage_schema.go
+++ b/pkg/domain/storage_schema.go
@@ -8,6 +8,7 @@ type StorageSchemaMigrator interface {
 	Steps(steps int) error
 	Version() (version uint, dirty bool, err error)
 	Force(version int) error //NB, int version vs uint in Migrate
+	Close() (source error, db error)
 }
 
 // SchemaVersionGetter is used to retrieve the current version of DB schema

--- a/pkg/storage/mock_storage_migrator_test.go
+++ b/pkg/storage/mock_storage_migrator_test.go
@@ -5,9 +5,8 @@
 package storage
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockStorageSchemaMigrator is a mock of StorageSchemaMigrator interface
@@ -31,6 +30,21 @@ func NewMockStorageSchemaMigrator(ctrl *gomock.Controller) *MockStorageSchemaMig
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockStorageSchemaMigrator) EXPECT() *MockStorageSchemaMigratorMockRecorder {
 	return m.recorder
+}
+
+// Close mocks base method
+func (m *MockStorageSchemaMigrator) Close() (error, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Close indicates an expected call of Close
+func (mr *MockStorageSchemaMigratorMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStorageSchemaMigrator)(nil).Close))
 }
 
 // Force mocks base method

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -46,6 +46,13 @@ func (sm *SchemaManager) EnsureConnected() error {
 		return nil
 	}
 	// migrator has stale connection or is not initialized properly
+	sourceCloseErr, dbCloseErr := sm.migrator.Close()
+	if dbCloseErr != nil { // we are primarily and by far interested in DB errors here
+		return dbCloseErr
+	}
+	if sourceCloseErr != nil {
+		return sourceCloseErr // but if something bad happened to FS handler - we still fail
+	}
 	sm.migrator, err = migrate.New(sm.MigrationsSource, sm.DataSourceURL)
 	return err
 }


### PR DESCRIPTION
Force reconnect/re-init the migrator on migration errors.

Manual testing shows this fixes the bug where failed migration renders the DB connection unusable for any subsequent migrations until the process is restarted.