### PR TITLE
Fix overlapping index names in schema migration

### DIFF
--- a/db-migrations/000007_publicip_resourceid_index.down.sql
+++ b/db-migrations/000007_publicip_resourceid_index.down.sql
@@ -1,3 +1,1 @@
-BEGIN;
-drop index if exists aws_public_ip_assignment.idx_aws_resource_id;
-COMMIT;
+drop index concurrently if exists idx_aws_resource_id;

--- a/db-migrations/000008_privateip_resourceid_index.down.sql
+++ b/db-migrations/000008_privateip_resourceid_index.down.sql
@@ -1,3 +1,1 @@
-BEGIN;
-drop index if exists aws_private_ip_assignment.idx_aws_resource_id;
-COMMIT;
+drop index concurrently if exists idx_aws_resource_id_private;

--- a/db-migrations/000008_privateip_resourceid_index.up.sql
+++ b/db-migrations/000008_privateip_resourceid_index.up.sql
@@ -1,4 +1,4 @@
 --- WARNING this is designed to run outside any transaction, so no BEGIN is present
 --- because `concurrently` (that avoids table write lock) is not compatible with DDL transactions
 --- This schema change is to exclusively be run in background
-create index concurrently if not exists idx_aws_resource_id on aws_private_ip_assignment (aws_resource_id);
+create index concurrently if not exists idx_aws_resource_id_private on aws_private_ip_assignment (aws_resource_id);


### PR DESCRIPTION
Using the same index name with different tables does not seem to work with PSQL, so the migration #8 was essentially no-op, as the index already existed. Giving index in #8  a unique name solves this (tested locally).