### PR TITLE
Adding ability to handle ENI relationships

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -776,6 +776,10 @@ components:
           type: array
           items:
             type: string
+        relatedResources:
+          type: array
+          items:
+            type: string
         changeType:
           type: string
           enum: [ADDED, DELETED]
@@ -809,6 +813,10 @@ components:
           items:
             type: string
         hostnames:
+          type: array
+          items:
+            type: string
+        relatedResources:
           type: array
           items:
             type: string

--- a/db-migrations/000012_adding_indexes_on_aws_resource_relationship.down.sql
+++ b/db-migrations/000012_adding_indexes_on_aws_resource_relationship.down.sql
@@ -1,0 +1,7 @@
+-- Removing indexes on aws_resource_relationship
+BEGIN;
+
+DROP INDEX CONCURRENTLY IF EXISTS aws_resource_relationship_idx_no_after;
+DROP INDEX CONCURRENTLY IF EXISTS aws_resource_relationship_idx_no_before;
+
+COMMIT;

--- a/db-migrations/000012_adding_indexes_on_aws_resource_relationship.up.sql
+++ b/db-migrations/000012_adding_indexes_on_aws_resource_relationship.up.sql
@@ -1,0 +1,7 @@
+-- Adding indexes on aws_resource_relationship
+BEGIN;
+
+CREATE UNIQUE INDEX IF NOT EXISTS aws_resource_relationship_idx_no_after ON aws_resource_relationship (not_before, arn_id, related_arn_id) WHERE not_after IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS aws_resource_relationship_idx_no_before ON aws_resource_relationship (not_after, arn_id, related_arn_id) WHERE not_before IS NULL;
+
+COMMIT;

--- a/pkg/domain/cloud.go
+++ b/pkg/domain/cloud.go
@@ -20,6 +20,7 @@ type NetworkChanges struct {
 	PrivateIPAddresses []string
 	PublicIPAddresses  []string
 	Hostnames          []string
+	RelatedResources   []string
 	ChangeType         string
 }
 

--- a/pkg/handlers/v1/cloud_insert.go
+++ b/pkg/handlers/v1/cloud_insert.go
@@ -24,6 +24,7 @@ type NetworkChanges struct {
 	PrivateIPAddresses []string `json:"privateIpAddresses"`
 	PublicIPAddresses  []string `json:"publicIpAddresses"`
 	Hostnames          []string `json:"hostnames"`
+	RelatedResources   []string `json:"relatedResources"`
 	ChangeType         string   `json:"changeType"`
 }
 
@@ -57,6 +58,7 @@ func (h *CloudInsertHandler) Handle(ctx context.Context, input CloudAssetChanges
 			PrivateIPAddresses: val.PrivateIPAddresses,
 			PublicIPAddresses:  val.PublicIPAddresses,
 			Hostnames:          val.Hostnames,
+			RelatedResources:   val.RelatedResources,
 			ChangeType:         val.ChangeType,
 		})
 	}

--- a/pkg/handlers/v1/cloud_insert_test.go
+++ b/pkg/handlers/v1/cloud_insert_test.go
@@ -33,6 +33,7 @@ func validInsertInput() CloudAssetChanges {
 				PrivateIPAddresses: []string{"1.1.1.1"},
 				PublicIPAddresses:  []string{"2.2.2.2"},
 				Hostnames:          []string{"hostname"},
+				RelatedResources:   []string{"app/marketp-ALB-eeeeeee5555555/ffffffff66666666"},
 				ChangeType:         "ADDED",
 			},
 		},

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -437,6 +437,16 @@ func (db *DB) StoreV2(ctx context.Context, cloudAssetChanges domain.CloudAssetCh
 					}
 				}
 			}
+			for _, res := range val.RelatedResources {
+				if strings.EqualFold(added, val.ChangeType) {
+					err = db.assignResourceRelationship(ctx, tx, arnID, res, cloudAssetChanges.ChangeTime)
+				} else {
+					err = db.releaseResourceRelationship(ctx, tx, arnID, res, cloudAssetChanges.ChangeTime)
+				}
+				if err != nil {
+					break
+				}
+			}
 			if err != nil {
 				break
 			}
@@ -1104,6 +1114,62 @@ func (db *DB) releasePublicIP(ctx context.Context, tx *sql.Tx, arnID string, ip 
 		return nil
 	}
 	_, err = tx.ExecContext(ctx, releasePublicIPQueryInsert, when, ip, arnID, hostname)
+	return err
+}
+
+func (db *DB) assignResourceRelationship(ctx context.Context, tx *sql.Tx, arnID string, resource string, when time.Time) error {
+	const assignResourceRelationshipQueryUpdate = `
+update aws_resource_relationship
+set not_before = $1
+where related_arn_id = $2
+  and not_before = to_timestamp(0)
+  and not_after > $1
+  and arn_id = $3;`
+
+	const assignResourceRelationshipQueryInsert = `
+insert into aws_resource_relationship
+    (not_before, related_arn_id, arn_id)
+values ($1, $2, $3) on conflict do nothing ;`
+
+	res, err := tx.ExecContext(ctx, assignResourceRelationshipQueryUpdate, when, resource, arnID)
+	if err != nil {
+		return err
+	}
+	changedRows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changedRows != 0 {
+		return nil
+	}
+	_, err = tx.ExecContext(ctx, assignResourceRelationshipQueryInsert, when, resource, arnID)
+	return err
+}
+
+func (db *DB) releaseResourceRelationship(ctx context.Context, tx *sql.Tx, arnID string, resource string, when time.Time) error {
+	const releaseResourceRelationshipQueryUpdate = `
+update aws_resource_relationship
+set not_after=$1
+where related_arn_id = $2
+  and arn_id = $3;`
+
+	const releaseResourceRelationshipQueryInsert = `
+insert into aws_resource_relationship
+    (not_before, not_after, related_arn_id, arn_id)
+values (to_timestamp(0), $1, $2, $3) on conflict do nothing ;`
+
+	res, err := tx.ExecContext(ctx, releaseResourceRelationshipQueryUpdate, when, resource, arnID)
+	if err != nil {
+		return err
+	}
+	changedRows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changedRows != 0 {
+		return nil
+	}
+	_, err = tx.ExecContext(ctx, releaseResourceRelationshipQueryInsert, when, resource, arnID)
 	return err
 }
 

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -1151,7 +1151,8 @@ func (db *DB) releaseResourceRelationship(ctx context.Context, tx *sql.Tx, arnID
 update aws_resource_relationship
 set not_after=$1
 where related_arn_id = $2
-  and arn_id = $3;`
+  and arn_id = $3
+  and not_after is null;`
 
 	const releaseResourceRelationshipQueryInsert = `
 insert into aws_resource_relationship

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -2199,7 +2199,6 @@ func TestStoreV2FailResourceRelationship(t *testing.T) {
 	}
 }
 
-
 func TestStoreV2FailTxOpen(t *testing.T) {
 	mockdb, mock, err := sqlmock.New()
 	if err != nil {

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -2167,6 +2167,39 @@ func TestStoreV2FailPublic(t *testing.T) {
 	}
 }
 
+func TestStoreV2FailResourceRelationship(t *testing.T) {
+	mockdb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockdb.Close()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	theDB := DB{
+		sqldb: mockdb,
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
+	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
+	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnError(errors.New("failed to store relationship"))
+	mock.ExpectRollback()
+
+	ctx := context.Background()
+
+	if err = theDB.StoreV2(ctx, fakeCloudChange("DELETED")); err == nil {
+		t.Errorf("error was expected while saving resource relationship: %s", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+
 func TestStoreV2FailTxOpen(t *testing.T) {
 	mockdb, mock, err := sqlmock.New()
 	if err != nil {

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -1932,11 +1932,13 @@ func fakeCloudChange(changeType string) domain.CloudAssetChanges {
 	privateIPs := []string{"4.3.2.1"}
 	publicIPs := []string{"8.7.6.5"}
 	hostnames := []string{"google.com"}
+	relatedResources := []string{"app/marketp-ALB-eeeeeee5555555/ffffffff66666666"}
 	networkChangesArray := []domain.NetworkChanges{
-		domain.NetworkChanges{
+		{
 			PrivateIPAddresses: privateIPs,
 			PublicIPAddresses:  publicIPs,
 			Hostnames:          hostnames,
+			RelatedResources:   relatedResources,
 			ChangeType:         changeType,
 		},
 	}
@@ -2052,6 +2054,7 @@ func TestStoreV2Assign(t *testing.T) {
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))              // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
 	mock.ExpectCommit()
 
 	ctx := context.Background()
@@ -2085,6 +2088,7 @@ func TestStoreV2Remove(t *testing.T) {
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))              // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
 	mock.ExpectCommit()
 
 	ctx := context.Background()


### PR DESCRIPTION
### Overview

Please refer [SID-511](https://asecurityteam.atlassian.net/browse/SID-511)
Also, creating indexes on aws_resource_relationship table as per existing system we only maintain one entry for ADDED resource until we see a DELETED event. Without index we will have multiple entries which is not ideal.

### Testing

* Unit teting
* Ran migrations on local
* Manual end to end tests via POST /v1/cloud/change