### PR TITLE
Replace inner joins with left joins on resource to champion

### DIFF
--- a/db-migrations/000013_updating_joins.down.sql
+++ b/db-migrations/000013_updating_joins.down.sql
@@ -1,0 +1,321 @@
+-- schema changes to create functions for APIs
+BEGIN;
+
+CREATE OR REPLACE FUNCTION get_resource_by_arn_id(aid VARCHAR, ts TIMESTAMP)
+    RETURNS TABLE
+            (
+                private_ip     INET,
+                public_ip      INET,
+                aws_hostname   VARCHAR,
+                resource_type  VARCHAR,
+                account        VARCHAR,
+                region         VARCHAR,
+                meta           JSONB,
+                aws_account_id INTEGER,
+                t_account      VARCHAR,
+                t_login        VARCHAR,
+                t_email        VARCHAR,
+                t_name         VARCHAR,
+                t_valid        BOOL,
+                p_login        VARCHAR,
+                p_email        VARCHAR,
+                p_name         VARCHAR,
+                p_valid        BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY WITH wres AS (SELECT pria.private_ip,
+                                      puia.public_ip,
+                                      puia.aws_hostname,
+                                      rt.resource_type,
+                                      aa.account,
+                                      ar.region,
+                                      res.meta,
+                                      res.aws_account_id
+                               FROM aws_resource res
+                                        LEFT JOIN aws_region ar ON res.aws_region_id = ar.id
+                                        LEFT JOIN aws_account aa ON res.aws_account_id = aa.id
+                                        LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id
+                                        LEFT JOIN aws_public_ip_assignment puia ON res.id = puia.aws_resource_id
+                                        LEFT JOIN aws_private_ip_assignment pria ON res.id = pria.aws_resource_id
+                               WHERE res.arn_id = aid
+                                 AND puia.not_before < ts
+                                 AND (puia.not_after IS NULL OR puia.not_after > ts)
+                                 AND pria.not_before < ts
+                                 AND (pria.not_after IS NULL OR pria.not_after > ts))
+                 SELECT wres.private_ip,
+                        wres.public_ip,
+                        wres.aws_hostname,
+                        wres.resource_type,
+                        wres.account,
+                        wres.region,
+                        wres.meta,
+                        wres.aws_account_id,
+                        b.t_account,
+                        b.t_login,
+                        b.t_email,
+                        b.t_name,
+                        b.t_valid,
+                        b.p_login,
+                        b.p_email,
+                        b.p_name,
+                        b.p_valid
+                 FROM wres
+                          JOIN
+                      (
+                          SELECT distinct iwres.aws_account_id, f.*
+                          FROM wres iwres,
+                               LATERAL get_owner_and_champions_by_account_id(iwres.aws_account_id) f
+                      ) b
+                      ON wres.account = b.t_account;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION get_owner_and_champions_by_account_id(id INTEGER)
+    RETURNS TABLE
+            (
+                t_account VARCHAR,
+                t_login   VARCHAR,
+                t_email   VARCHAR,
+                t_name    VARCHAR,
+                t_valid   BOOL,
+                p_login   VARCHAR,
+                p_email   VARCHAR,
+                p_name    VARCHAR,
+                p_valid   BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY SELECT t.account,
+                        t.login,
+                        t.email,
+                        t.name,
+                        t.valid,
+                        p.login,
+                        p.email,
+                        p.name,
+                        p.valid
+                 FROM (SELECT aa.account,
+                              ow.login,
+                              ow.email,
+                              ow.name,
+                              ow.valid,
+                              ac.person_id
+                       FROM account_owner ao
+                                LEFT JOIN aws_account aa ON ao.aws_account_id = aa.id
+                                LEFT JOIN person ow ON ao.person_id = ow.id
+                                LEFT JOIN account_champion ac ON ao.aws_account_id = ac.aws_account_id
+                       WHERE ao.aws_account_id = get_owner_and_champions_by_account_id.id) t
+                          LEFT JOIN person p ON t.person_id = p.id;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION get_resource_by_hostname(name VARCHAR, ts TIMESTAMP)
+    RETURNS TABLE
+            (
+                public_ip     INET,
+                aws_hostname  VARCHAR,
+                arn_id        VARCHAR,
+                meta          JSONB,
+                region        VARCHAR,
+                resource_type VARCHAR,
+                account       VARCHAR,
+                id            INTEGER,
+                t_account     VARCHAR,
+                t_login       VARCHAR,
+                t_email       VARCHAR,
+                t_name        VARCHAR,
+                t_valid       BOOL,
+                p_login       VARCHAR,
+                p_email       VARCHAR,
+                p_name        VARCHAR,
+                p_valid       BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY WITH wres AS (SELECT ia.public_ip,
+                                      ia.aws_hostname,
+                                      res.arn_id,
+                                      res.meta,
+                                      ar.region,
+                                      rt.resource_type,
+                                      aa.account,
+                                      aa.id
+                               FROM aws_public_ip_assignment ia
+                                        LEFT JOIN aws_resource res ON ia.aws_resource_id = res.id
+                                        LEFT JOIN aws_region ar ON res.aws_region_id = ar.id
+                                        LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id
+                                        LEFT JOIN aws_account aa ON res.aws_account_id = aa.id
+                               WHERE ia.aws_hostname = name
+                                 AND ia.not_before < ts
+                                 AND (ia.not_after IS NULL OR ia.not_after > ts))
+                 SELECT wres.public_ip,
+                        wres.aws_hostname,
+                        wres.arn_id,
+                        wres.meta,
+                        wres.region,
+                        wres.resource_type,
+                        wres.account,
+                        wres.id,
+                        b.t_account,
+                        b.t_login,
+                        b.t_email,
+                        b.t_name,
+                        b.t_valid,
+                        b.p_login,
+                        b.p_email,
+                        b.p_name,
+                        b.p_valid
+                 FROM wres
+                          JOIN
+                      (
+                          SELECT distinct iwres.id, f.*
+                          FROM wres iwres,
+                               LATERAL get_owner_and_champions_by_account_id(iwres.id) f
+                      ) b
+                      ON wres.account = b.t_account;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION get_resource_by_private_ip(pip INET, ts TIMESTAMP)
+    RETURNS TABLE
+            (
+                private_ip    INET,
+                arn_id        VARCHAR,
+                meta          JSONB,
+                region        VARCHAR,
+                resource_type VARCHAR,
+                account       VARCHAR,
+                id            INTEGER,
+                t_account     VARCHAR,
+                t_login       VARCHAR,
+                t_email       VARCHAR,
+                t_name        VARCHAR,
+                t_valid       BOOL,
+                p_login       VARCHAR,
+                p_email       VARCHAR,
+                p_name        VARCHAR,
+                p_valid       BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY WITH wres AS (SELECT ia.private_ip,
+                                      res.arn_id,
+                                      res.meta,
+                                      ar.region,
+                                      rt.resource_type,
+                                      aa.account,
+                                      aa.id
+                               FROM aws_private_ip_assignment ia
+                                        LEFT JOIN aws_resource res ON ia.aws_resource_id = res.id
+                                        LEFT JOIN aws_region ar ON res.aws_region_id = ar.id
+                                        LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id
+                                        LEFT JOIN aws_account aa ON res.aws_account_id = aa.id
+                               WHERE ia.private_ip = pip
+                                 AND ia.not_before < ts
+                                 AND (ia.not_after IS NULL OR ia.not_after > ts))
+                 SELECT wres.private_ip,
+                        wres.arn_id,
+                        wres.meta,
+                        wres.region,
+                        wres.resource_type,
+                        wres.account,
+                        wres.id,
+                        b.t_account,
+                        b.t_login,
+                        b.t_email,
+                        b.t_name,
+                        b.t_valid,
+                        b.p_login,
+                        b.p_email,
+                        b.p_name,
+                        b.p_valid
+                 FROM wres
+                          JOIN
+                      (
+                          SELECT distinct iwres.id, f.*
+                          FROM wres iwres,
+                               LATERAL get_owner_and_champions_by_account_id(iwres.id) f
+                      ) b
+                      ON wres.account = b.t_account;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION get_resource_by_public_ip(pip INET, ts TIMESTAMP)
+    RETURNS TABLE
+            (
+                public_ip     INET,
+                aws_hostname  VARCHAR,
+                arn_id        VARCHAR,
+                meta          JSONB,
+                region        VARCHAR,
+                resource_type VARCHAR,
+                account       VARCHAR,
+                id            INTEGER,
+                t_account     VARCHAR,
+                t_login       VARCHAR,
+                t_email       VARCHAR,
+                t_name        VARCHAR,
+                t_valid       BOOL,
+                p_login       VARCHAR,
+                p_email       VARCHAR,
+                p_name        VARCHAR,
+                p_valid       BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY WITH wres AS (SELECT ia.public_ip,
+                                      ia.aws_hostname,
+                                      res.arn_id,
+                                      res.meta,
+                                      ar.region,
+                                      rt.resource_type,
+                                      aa.account,
+                                      aa.id
+                               FROM aws_public_ip_assignment ia
+                                        LEFT JOIN aws_resource res ON ia.aws_resource_id = res.id
+                                        LEFT JOIN aws_region ar ON res.aws_region_id = ar.id
+                                        LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id
+                                        LEFT JOIN aws_account aa ON res.aws_account_id = aa.id
+                               WHERE ia.public_ip = pip
+                                 AND ia.not_before < ts
+                                 AND (ia.not_after IS NULL OR ia.not_after > ts))
+                 SELECT wres.public_ip,
+                        wres.aws_hostname,
+                        wres.arn_id,
+                        wres.meta,
+                        wres.region,
+                        wres.resource_type,
+                        wres.account,
+                        wres.id,
+                        b.t_account,
+                        b.t_login,
+                        b.t_email,
+                        b.t_name,
+                        b.t_valid,
+                        b.p_login,
+                        b.p_email,
+                        b.p_name,
+                        b.p_valid
+                 FROM wres
+                          JOIN
+                      (
+                          SELECT distinct iwres.id, f.*
+                          FROM wres iwres,
+                               LATERAL get_owner_and_champions_by_account_id(iwres.id) f
+                      ) b
+                      ON wres.account = b.t_account;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+COMMIT;

--- a/db-migrations/000013_updating_joins.down.sql
+++ b/db-migrations/000013_updating_joins.down.sql
@@ -73,47 +73,6 @@ END;
 $$
     LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION get_owner_and_champions_by_account_id(id INTEGER)
-    RETURNS TABLE
-            (
-                t_account VARCHAR,
-                t_login   VARCHAR,
-                t_email   VARCHAR,
-                t_name    VARCHAR,
-                t_valid   BOOL,
-                p_login   VARCHAR,
-                p_email   VARCHAR,
-                p_name    VARCHAR,
-                p_valid   BOOL
-            )
-AS
-$$
-BEGIN
-    RETURN QUERY SELECT t.account,
-                        t.login,
-                        t.email,
-                        t.name,
-                        t.valid,
-                        p.login,
-                        p.email,
-                        p.name,
-                        p.valid
-                 FROM (SELECT aa.account,
-                              ow.login,
-                              ow.email,
-                              ow.name,
-                              ow.valid,
-                              ac.person_id
-                       FROM account_owner ao
-                                LEFT JOIN aws_account aa ON ao.aws_account_id = aa.id
-                                LEFT JOIN person ow ON ao.person_id = ow.id
-                                LEFT JOIN account_champion ac ON ao.aws_account_id = ac.aws_account_id
-                       WHERE ao.aws_account_id = get_owner_and_champions_by_account_id.id) t
-                          LEFT JOIN person p ON t.person_id = p.id;
-END;
-$$
-    LANGUAGE 'plpgsql';
-
 CREATE OR REPLACE FUNCTION get_resource_by_hostname(name VARCHAR, ts TIMESTAMP)
     RETURNS TABLE
             (

--- a/db-migrations/000013_updating_joins.up.sql
+++ b/db-migrations/000013_updating_joins.up.sql
@@ -1,4 +1,4 @@
--- schema changes to create functions for APIs
+-- update functions to use left joins
 BEGIN;
 
 CREATE OR REPLACE FUNCTION get_resource_by_arn_id(aid VARCHAR, ts TIMESTAMP)

--- a/db-migrations/000013_updating_joins.up.sql
+++ b/db-migrations/000013_updating_joins.up.sql
@@ -1,0 +1,321 @@
+-- schema changes to create functions for APIs
+BEGIN;
+
+CREATE OR REPLACE FUNCTION get_resource_by_arn_id(aid VARCHAR, ts TIMESTAMP)
+    RETURNS TABLE
+            (
+                private_ip     INET,
+                public_ip      INET,
+                aws_hostname   VARCHAR,
+                resource_type  VARCHAR,
+                account        VARCHAR,
+                region         VARCHAR,
+                meta           JSONB,
+                aws_account_id INTEGER,
+                t_account      VARCHAR,
+                t_login        VARCHAR,
+                t_email        VARCHAR,
+                t_name         VARCHAR,
+                t_valid        BOOL,
+                p_login        VARCHAR,
+                p_email        VARCHAR,
+                p_name         VARCHAR,
+                p_valid        BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY WITH wres AS (SELECT pria.private_ip,
+                                      puia.public_ip,
+                                      puia.aws_hostname,
+                                      rt.resource_type,
+                                      aa.account,
+                                      ar.region,
+                                      res.meta,
+                                      res.aws_account_id
+                               FROM aws_resource res
+                                        LEFT JOIN aws_region ar ON res.aws_region_id = ar.id
+                                        LEFT JOIN aws_account aa ON res.aws_account_id = aa.id
+                                        LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id
+                                        LEFT JOIN aws_public_ip_assignment puia ON res.id = puia.aws_resource_id
+                                        LEFT JOIN aws_private_ip_assignment pria ON res.id = pria.aws_resource_id
+                               WHERE res.arn_id = aid
+                                 AND puia.not_before < ts
+                                 AND (puia.not_after IS NULL OR puia.not_after > ts)
+                                 AND pria.not_before < ts
+                                 AND (pria.not_after IS NULL OR pria.not_after > ts))
+                 SELECT wres.private_ip,
+                        wres.public_ip,
+                        wres.aws_hostname,
+                        wres.resource_type,
+                        wres.account,
+                        wres.region,
+                        wres.meta,
+                        wres.aws_account_id,
+                        b.t_account,
+                        b.t_login,
+                        b.t_email,
+                        b.t_name,
+                        b.t_valid,
+                        b.p_login,
+                        b.p_email,
+                        b.p_name,
+                        b.p_valid
+                 FROM wres
+                          LEFT JOIN
+                      (
+                          SELECT distinct iwres.aws_account_id, f.*
+                          FROM wres iwres,
+                               LATERAL get_owner_and_champions_by_account_id(iwres.aws_account_id) f
+                      ) b
+                      ON wres.account = b.t_account;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION get_owner_and_champions_by_account_id(id INTEGER)
+    RETURNS TABLE
+            (
+                t_account VARCHAR,
+                t_login   VARCHAR,
+                t_email   VARCHAR,
+                t_name    VARCHAR,
+                t_valid   BOOL,
+                p_login   VARCHAR,
+                p_email   VARCHAR,
+                p_name    VARCHAR,
+                p_valid   BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY SELECT t.account,
+                        t.login,
+                        t.email,
+                        t.name,
+                        t.valid,
+                        p.login,
+                        p.email,
+                        p.name,
+                        p.valid
+                 FROM (SELECT aa.account,
+                              ow.login,
+                              ow.email,
+                              ow.name,
+                              ow.valid,
+                              ac.person_id
+                       FROM account_owner ao
+                                LEFT JOIN aws_account aa ON ao.aws_account_id = aa.id
+                                LEFT JOIN person ow ON ao.person_id = ow.id
+                                LEFT JOIN account_champion ac ON ao.aws_account_id = ac.aws_account_id
+                       WHERE ao.aws_account_id = get_owner_and_champions_by_account_id.id) t
+                          LEFT JOIN person p ON t.person_id = p.id;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION get_resource_by_hostname(name VARCHAR, ts TIMESTAMP)
+    RETURNS TABLE
+            (
+                public_ip     INET,
+                aws_hostname  VARCHAR,
+                arn_id        VARCHAR,
+                meta          JSONB,
+                region        VARCHAR,
+                resource_type VARCHAR,
+                account       VARCHAR,
+                id            INTEGER,
+                t_account     VARCHAR,
+                t_login       VARCHAR,
+                t_email       VARCHAR,
+                t_name        VARCHAR,
+                t_valid       BOOL,
+                p_login       VARCHAR,
+                p_email       VARCHAR,
+                p_name        VARCHAR,
+                p_valid       BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY WITH wres AS (SELECT ia.public_ip,
+                                      ia.aws_hostname,
+                                      res.arn_id,
+                                      res.meta,
+                                      ar.region,
+                                      rt.resource_type,
+                                      aa.account,
+                                      aa.id
+                               FROM aws_public_ip_assignment ia
+                                        LEFT JOIN aws_resource res ON ia.aws_resource_id = res.id
+                                        LEFT JOIN aws_region ar ON res.aws_region_id = ar.id
+                                        LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id
+                                        LEFT JOIN aws_account aa ON res.aws_account_id = aa.id
+                               WHERE ia.aws_hostname = name
+                                 AND ia.not_before < ts
+                                 AND (ia.not_after IS NULL OR ia.not_after > ts))
+                 SELECT wres.public_ip,
+                        wres.aws_hostname,
+                        wres.arn_id,
+                        wres.meta,
+                        wres.region,
+                        wres.resource_type,
+                        wres.account,
+                        wres.id,
+                        b.t_account,
+                        b.t_login,
+                        b.t_email,
+                        b.t_name,
+                        b.t_valid,
+                        b.p_login,
+                        b.p_email,
+                        b.p_name,
+                        b.p_valid
+                 FROM wres
+                          LEFT JOIN
+                      (
+                          SELECT distinct iwres.id, f.*
+                          FROM wres iwres,
+                               LATERAL get_owner_and_champions_by_account_id(iwres.id) f
+                      ) b
+                      ON wres.account = b.t_account;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION get_resource_by_private_ip(pip INET, ts TIMESTAMP)
+    RETURNS TABLE
+            (
+                private_ip    INET,
+                arn_id        VARCHAR,
+                meta          JSONB,
+                region        VARCHAR,
+                resource_type VARCHAR,
+                account       VARCHAR,
+                id            INTEGER,
+                t_account     VARCHAR,
+                t_login       VARCHAR,
+                t_email       VARCHAR,
+                t_name        VARCHAR,
+                t_valid       BOOL,
+                p_login       VARCHAR,
+                p_email       VARCHAR,
+                p_name        VARCHAR,
+                p_valid       BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY WITH wres AS (SELECT ia.private_ip,
+                                      res.arn_id,
+                                      res.meta,
+                                      ar.region,
+                                      rt.resource_type,
+                                      aa.account,
+                                      aa.id
+                               FROM aws_private_ip_assignment ia
+                                        LEFT JOIN aws_resource res ON ia.aws_resource_id = res.id
+                                        LEFT JOIN aws_region ar ON res.aws_region_id = ar.id
+                                        LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id
+                                        LEFT JOIN aws_account aa ON res.aws_account_id = aa.id
+                               WHERE ia.private_ip = pip
+                                 AND ia.not_before < ts
+                                 AND (ia.not_after IS NULL OR ia.not_after > ts))
+                 SELECT wres.private_ip,
+                        wres.arn_id,
+                        wres.meta,
+                        wres.region,
+                        wres.resource_type,
+                        wres.account,
+                        wres.id,
+                        b.t_account,
+                        b.t_login,
+                        b.t_email,
+                        b.t_name,
+                        b.t_valid,
+                        b.p_login,
+                        b.p_email,
+                        b.p_name,
+                        b.p_valid
+                 FROM wres
+                          LEFT JOIN
+                      (
+                          SELECT distinct iwres.id, f.*
+                          FROM wres iwres,
+                               LATERAL get_owner_and_champions_by_account_id(iwres.id) f
+                      ) b
+                      ON wres.account = b.t_account;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION get_resource_by_public_ip(pip INET, ts TIMESTAMP)
+    RETURNS TABLE
+            (
+                public_ip     INET,
+                aws_hostname  VARCHAR,
+                arn_id        VARCHAR,
+                meta          JSONB,
+                region        VARCHAR,
+                resource_type VARCHAR,
+                account       VARCHAR,
+                id            INTEGER,
+                t_account     VARCHAR,
+                t_login       VARCHAR,
+                t_email       VARCHAR,
+                t_name        VARCHAR,
+                t_valid       BOOL,
+                p_login       VARCHAR,
+                p_email       VARCHAR,
+                p_name        VARCHAR,
+                p_valid       BOOL
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY WITH wres AS (SELECT ia.public_ip,
+                                      ia.aws_hostname,
+                                      res.arn_id,
+                                      res.meta,
+                                      ar.region,
+                                      rt.resource_type,
+                                      aa.account,
+                                      aa.id
+                               FROM aws_public_ip_assignment ia
+                                        LEFT JOIN aws_resource res ON ia.aws_resource_id = res.id
+                                        LEFT JOIN aws_region ar ON res.aws_region_id = ar.id
+                                        LEFT JOIN aws_resource_type rt ON res.aws_resource_type_id = rt.id
+                                        LEFT JOIN aws_account aa ON res.aws_account_id = aa.id
+                               WHERE ia.public_ip = pip
+                                 AND ia.not_before < ts
+                                 AND (ia.not_after IS NULL OR ia.not_after > ts))
+                 SELECT wres.public_ip,
+                        wres.aws_hostname,
+                        wres.arn_id,
+                        wres.meta,
+                        wres.region,
+                        wres.resource_type,
+                        wres.account,
+                        wres.id,
+                        b.t_account,
+                        b.t_login,
+                        b.t_email,
+                        b.t_name,
+                        b.t_valid,
+                        b.p_login,
+                        b.p_email,
+                        b.p_name,
+                        b.p_valid
+                 FROM wres
+                          LEFT JOIN
+                      (
+                          SELECT distinct iwres.id, f.*
+                          FROM wres iwres,
+                               LATERAL get_owner_and_champions_by_account_id(iwres.id) f
+                      ) b
+                      ON wres.account = b.t_account;
+END;
+$$
+    LANGUAGE 'plpgsql';
+
+COMMIT;

--- a/db-migrations/000013_updating_joins.up.sql
+++ b/db-migrations/000013_updating_joins.up.sql
@@ -73,47 +73,6 @@ END;
 $$
     LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION get_owner_and_champions_by_account_id(id INTEGER)
-    RETURNS TABLE
-            (
-                t_account VARCHAR,
-                t_login   VARCHAR,
-                t_email   VARCHAR,
-                t_name    VARCHAR,
-                t_valid   BOOL,
-                p_login   VARCHAR,
-                p_email   VARCHAR,
-                p_name    VARCHAR,
-                p_valid   BOOL
-            )
-AS
-$$
-BEGIN
-    RETURN QUERY SELECT t.account,
-                        t.login,
-                        t.email,
-                        t.name,
-                        t.valid,
-                        p.login,
-                        p.email,
-                        p.name,
-                        p.valid
-                 FROM (SELECT aa.account,
-                              ow.login,
-                              ow.email,
-                              ow.name,
-                              ow.valid,
-                              ac.person_id
-                       FROM account_owner ao
-                                LEFT JOIN aws_account aa ON ao.aws_account_id = aa.id
-                                LEFT JOIN person ow ON ao.person_id = ow.id
-                                LEFT JOIN account_champion ac ON ao.aws_account_id = ac.aws_account_id
-                       WHERE ao.aws_account_id = get_owner_and_champions_by_account_id.id) t
-                          LEFT JOIN person p ON t.person_id = p.id;
-END;
-$$
-    LANGUAGE 'plpgsql';
-
 CREATE OR REPLACE FUNCTION get_resource_by_hostname(name VARCHAR, ts TIMESTAMP)
     RETURNS TABLE
             (

--- a/integration/tests/client_test.go
+++ b/integration/tests/client_test.go
@@ -14,7 +14,7 @@ import (
 
 var assetInventoryAPI *openapi.APIClient
 var schemaVersion int32 = 1
-var maxSchema int32 = 11 // TODO: extrapolate this somewhere?
+var maxSchema int32 = 13 // TODO: extrapolate this somewhere?
 
 func TestMain(m *testing.M) {
 	config := openapi.NewConfiguration()
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 
 func TestHealthcheck(t *testing.T) {
 	// Example: check every schema version against health check.
-	for schema := schemaVersion; schema < maxSchema; schema++ {
+	for schema := schemaVersion; schema <= maxSchema; schema++ {
 		tt := []struct {
 			Name string
 		}{
@@ -45,8 +45,10 @@ func TestHealthcheck(t *testing.T) {
 			t.Run(test.Name, fn)
 		}
 
-		err := setSchemaVersion(schema + 1)
-		assert.NoError(t, err, "The database migration should not return an error")
+		if schema < maxSchema {
+			err := setSchemaVersion(schema + 1)
+			assert.NoError(t, err, "The database migration should not return an error")
+		}
 	}
 }
 

--- a/pkg/domain/cloud.go
+++ b/pkg/domain/cloud.go
@@ -39,15 +39,15 @@ type CloudAssetDetails struct {
 
 // AccountOwner represents an AWS account with its owner and account champions
 type AccountOwner struct {
-	AccountID string
+	AccountID *string
 	Owner     Person
 	Champions []Person
 }
 
 // Person represents details about a person in Atlassian
 type Person struct {
-	Name  string
-	Login string
-	Email string
-	Valid bool
+	Name  *string
+	Login *string
+	Email *string
+	Valid *bool
 }

--- a/pkg/handlers/v1/cloud_fetch_test.go
+++ b/pkg/handlers/v1/cloud_fetch_test.go
@@ -421,12 +421,12 @@ func TestFetchByARNIDSuccess(t *testing.T) {
 			Hostnames:          []string{"foo"},
 			ARN:                "arnid",
 			AccountOwner: domain.AccountOwner{
-				AccountID: "abc123",
+				AccountID: toStringPointer("abc123"),
 				Owner: domain.Person{
-					Name:  "fake name",
-					Login: "fake",
-					Email: "fake@atlassian.com",
-					Valid: true,
+					Name:  toStringPointer("fake name"),
+					Login: toStringPointer("fake"),
+					Email: toStringPointer("fake@atlassian.com"),
+					Valid: toBoolPointer(true),
 				},
 			},
 		},
@@ -458,12 +458,12 @@ func TestExtractOutput(t *testing.T) {
 					Region:       "Region",
 					ARN:          "arn",
 					AccountOwner: domain.AccountOwner{
-						AccountID: "accountID",
+						AccountID: toStringPointer("accountID"),
 						Owner: domain.Person{
-							Name:  "name",
-							Login: "login",
-							Email: "email@atlassian.com",
-							Valid: false,
+							Name:  toStringPointer("name"),
+							Login: toStringPointer("login"),
+							Email: toStringPointer("email@atlassian.com"),
+							Valid: toBoolPointer(false),
 						},
 					},
 				},
@@ -480,12 +480,12 @@ func TestExtractOutput(t *testing.T) {
 						ARN:                "arn",
 						Tags:               make(map[string]string),
 						AccountOwner: domain.AccountOwner{
-							AccountID: "accountID",
+							AccountID: toStringPointer("accountID"),
 							Owner: domain.Person{
-								Name:  "name",
-								Login: "login",
-								Email: "email@atlassian.com",
-								Valid: false,
+								Name:  toStringPointer("name"),
+								Login: toStringPointer("login"),
+								Email: toStringPointer("email@atlassian.com"),
+								Valid: toBoolPointer(false),
 							},
 							Champions: make([]domain.Person, 0),
 						},
@@ -501,25 +501,25 @@ func TestExtractOutput(t *testing.T) {
 					PublicIPAddresses:  []string{"1.1.1.1"},
 					PrivateIPAddresses: []string{"10.1.1.1"},
 					AccountOwner: domain.AccountOwner{
-						AccountID: "accountID",
+						AccountID: toStringPointer("accountID"),
 						Owner: domain.Person{
-							Name:  "name",
-							Login: "login",
-							Email: "email@atlassian.com",
-							Valid: true,
+							Name:  toStringPointer("name"),
+							Login: toStringPointer("login"),
+							Email: toStringPointer("email@atlassian.com"),
+							Valid: toBoolPointer(true),
 						},
 						Champions: []domain.Person{
 							{
-								Name:  "name",
-								Login: "login",
-								Email: "email@atlassian.com",
-								Valid: true,
+								Name:  toStringPointer("name"),
+								Login: toStringPointer("login"),
+								Email: toStringPointer("email@atlassian.com"),
+								Valid: toBoolPointer(true),
 							},
 							{
-								Name:  "name2",
-								Login: "login2",
-								Email: "email2@atlassian.com",
-								Valid: true,
+								Name:  toStringPointer("name2"),
+								Login: toStringPointer("login2"),
+								Email: toStringPointer("email2@atlassian.com"),
+								Valid: toBoolPointer(true),
 							},
 						},
 					},
@@ -529,25 +529,25 @@ func TestExtractOutput(t *testing.T) {
 					PublicIPAddresses:  []string{"2.2.2.2"},
 					PrivateIPAddresses: []string{"10.2.2.2"},
 					AccountOwner: domain.AccountOwner{
-						AccountID: "accountID2",
+						AccountID: toStringPointer("accountID2"),
 						Owner: domain.Person{
-							Name:  "name",
-							Login: "login",
-							Email: "email@atlassian.com",
-							Valid: true,
+							Name:  toStringPointer("name"),
+							Login: toStringPointer("login"),
+							Email: toStringPointer("email@atlassian.com"),
+							Valid: toBoolPointer(true),
 						},
 						Champions: []domain.Person{
 							{
-								Name:  "name",
-								Login: "login",
-								Email: "email@atlassian.com",
-								Valid: true,
+								Name:  toStringPointer("name"),
+								Login: toStringPointer("login"),
+								Email: toStringPointer("email@atlassian.com"),
+								Valid: toBoolPointer(true),
 							},
 							{
-								Name:  "name2",
-								Login: "login2",
-								Email: "email2@atlassian.com",
-								Valid: true,
+								Name:  toStringPointer("name2"),
+								Login: toStringPointer("login2"),
+								Email: toStringPointer("email2@atlassian.com"),
+								Valid: toBoolPointer(true),
 							},
 						},
 					},
@@ -561,25 +561,25 @@ func TestExtractOutput(t *testing.T) {
 						Hostnames:          []string{"hostname"},
 						Tags:               make(map[string]string),
 						AccountOwner: domain.AccountOwner{
-							AccountID: "accountID",
+							AccountID: toStringPointer("accountID"),
 							Owner: domain.Person{
-								Name:  "name",
-								Login: "login",
-								Email: "email@atlassian.com",
-								Valid: true,
+								Name:  toStringPointer("name"),
+								Login: toStringPointer("login"),
+								Email: toStringPointer("email@atlassian.com"),
+								Valid: toBoolPointer(true),
 							},
 							Champions: []domain.Person{
 								{
-									Name:  "name",
-									Login: "login",
-									Email: "email@atlassian.com",
-									Valid: true,
+									Name:  toStringPointer("name"),
+									Login: toStringPointer("login"),
+									Email: toStringPointer("email@atlassian.com"),
+									Valid: toBoolPointer(true),
 								},
 								{
-									Name:  "name2",
-									Login: "login2",
-									Email: "email2@atlassian.com",
-									Valid: true,
+									Name:  toStringPointer("name2"),
+									Login: toStringPointer("login2"),
+									Email: toStringPointer("email2@atlassian.com"),
+									Valid: toBoolPointer(true),
 								},
 							},
 						},
@@ -590,25 +590,25 @@ func TestExtractOutput(t *testing.T) {
 						Hostnames:          []string{"hostname"},
 						Tags:               make(map[string]string),
 						AccountOwner: domain.AccountOwner{
-							AccountID: "accountID2",
+							AccountID: toStringPointer("accountID2"),
 							Owner: domain.Person{
-								Name:  "name",
-								Login: "login",
-								Email: "email@atlassian.com",
-								Valid: true,
+								Name:  toStringPointer("name"),
+								Login: toStringPointer("login"),
+								Email: toStringPointer("email@atlassian.com"),
+								Valid: toBoolPointer(true),
 							},
 							Champions: []domain.Person{
 								{
-									Name:  "name",
-									Login: "login",
-									Email: "email@atlassian.com",
-									Valid: true,
+									Name:  toStringPointer("name"),
+									Login: toStringPointer("login"),
+									Email: toStringPointer("email@atlassian.com"),
+									Valid: toBoolPointer(true),
 								},
 								{
-									Name:  "name2",
-									Login: "login2",
-									Email: "email2@atlassian.com",
-									Valid: true,
+									Name:  toStringPointer("name2"),
+									Login: toStringPointer("login2"),
+									Email: toStringPointer("email2@atlassian.com"),
+									Valid: toBoolPointer(true),
 								},
 							},
 						},
@@ -681,4 +681,14 @@ func Test_fetchAllByTimeStampParametersForToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Helper function to convert strings to pointers (for nullability)
+func toStringPointer(s string) *string {
+	return &s
+}
+
+// Helper function to convert booleans to pointers (for nullability)
+func toBoolPointer(b bool) *bool {
+	return &b
 }

--- a/pkg/handlers/v1/insert_account_owner.go
+++ b/pkg/handlers/v1/insert_account_owner.go
@@ -34,21 +34,21 @@ func (h *AccountOwnerInsertHandler) Handle(ctx context.Context, input AccountOwn
 	logger := h.LogFn(ctx)
 
 	accountOwner := domain.AccountOwner{
-		AccountID: input.AccountID,
+		AccountID: &input.AccountID,
 		Owner: domain.Person{
-			Name:  input.Owner.Name,
-			Login: input.Owner.Login,
-			Email: input.Owner.Email,
-			Valid: input.Owner.Valid,
+			Name:  &input.Owner.Name,
+			Login: &input.Owner.Login,
+			Email: &input.Owner.Email,
+			Valid: &input.Owner.Valid,
 		},
 		Champions: make([]domain.Person, 0, len(input.Champions)),
 	}
 	for _, val := range input.Champions {
 		accountOwner.Champions = append(accountOwner.Champions, domain.Person{
-			Name:  val.Name,
-			Login: val.Login,
-			Email: val.Email,
-			Valid: val.Valid,
+			Name:  &val.Name,
+			Login: &val.Login,
+			Email: &val.Email,
+			Valid: &val.Valid,
 		})
 	}
 

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -697,10 +697,10 @@ func (db *DB) runFetchByIPQuery(ctx context.Context, isPrivateIP bool, query str
 		var hostname sql.NullString
 		var ipAddress string // no need for sql.NullBool as the DB column is guaranteed a value
 		var accountID int
-		var chLogin string
-		var chEmail string
-		var chName string
-		var chValid bool
+		var chLogin *string
+		var chEmail *string
+		var chName *string
+		var chValid *bool
 
 		if isPrivateIP {
 			err = rows.Scan(&ipAddress, &row.ARN, &metaBytes, &row.Region, &row.ResourceType, &row.AccountID,
@@ -746,7 +746,7 @@ func (db *DB) runFetchByIPQuery(ctx context.Context, isPrivateIP bool, query str
 
 		found := false
 		for _, val := range tempMap[row.ARN].AccountOwner.Champions {
-			if strings.EqualFold(val.Email, chEmail) {
+			if strings.EqualFold(*val.Email, *chEmail) {
 				found = true
 				break
 			}
@@ -865,10 +865,10 @@ func (db *DB) FetchByARNID(ctx context.Context, when time.Time, arnID string) ([
 		}
 
 		tempChampionsMap[chLogin+chEmail] = domain.Person{
-			Login: chLogin,
-			Email: chEmail,
-			Name:  chName,
-			Valid: chValid,
+			Login: &chLogin,
+			Email: &chEmail,
+			Name:  &chName,
+			Valid: &chValid,
 		}
 	}
 	rows.Close()

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -363,19 +363,19 @@ func TestGetPrivateIPsAtTimeM1Schema(t *testing.T) {
 		ARN:                "rid",
 		Tags:               map[string]string{"hi": "there1"},
 		AccountOwner: domain.AccountOwner{
-			AccountID: "aid",
+			AccountID: toStringPointer("aid"),
 			Owner: domain.Person{
-				Login: "login",
-				Email: "email@atlassian.com",
-				Name:  "name",
-				Valid: true,
+				Login: toStringPointer("login"),
+				Email: toStringPointer("email@atlassian.com"),
+				Name:  toStringPointer("name"),
+				Valid: toBoolPointer(true),
 			},
 			Champions: []domain.Person{
 				{
-					Login: "login2",
-					Email: "email2@atlassian.com",
-					Name:  "name2",
-					Valid: true,
+					Login: toStringPointer("login2"),
+					Email: toStringPointer("email2@atlassian.com"),
+					Name:  toStringPointer("name2"),
+					Valid: toBoolPointer(true),
 				},
 			},
 		},
@@ -452,19 +452,19 @@ func TestGetPublicIPsAtTimeM1Schema(t *testing.T) {
 		ARN:               "rid",
 		Tags:              map[string]string{"hi": "there1"},
 		AccountOwner: domain.AccountOwner{
-			AccountID: "aid",
+			AccountID: toStringPointer("aid"),
 			Owner: domain.Person{
-				Login: "login",
-				Email: "email@atlassian.com",
-				Name:  "name",
-				Valid: true,
+				Login: toStringPointer("login"),
+				Email: toStringPointer("email@atlassian.com"),
+				Name:  toStringPointer("name"),
+				Valid: toBoolPointer(true),
 			},
 			Champions: []domain.Person{
 				{
-					Login: "login2",
-					Email: "email2@atlassian.com",
-					Name:  "name2",
-					Valid: true,
+					Login: toStringPointer("login2"),
+					Email: toStringPointer("email2@atlassian.com"),
+					Name:  toStringPointer("name2"),
+					Valid: toBoolPointer(true),
 				},
 			},
 		},
@@ -552,19 +552,19 @@ func TestGetPrivateIPsAtTimeMultiRowsM1Schema(t *testing.T) {
 			ARN:                "rid",
 			Tags:               map[string]string{"hi": "there1"},
 			AccountOwner: domain.AccountOwner{
-				AccountID: "aid",
+				AccountID: toStringPointer("aid"),
 				Owner: domain.Person{
-					Login: "login",
-					Email: "email@atlassian.com",
-					Name:  "name",
-					Valid: true,
+					Login: toStringPointer("login"),
+					Email: toStringPointer("email@atlassian.com"),
+					Name:  toStringPointer("name"),
+					Valid: toBoolPointer(true),
 				},
 				Champions: []domain.Person{
 					{
-						Login: "login2",
-						Email: "email2@atlassian.com",
-						Name:  "name2",
-						Valid: true,
+						Login: toStringPointer("login2"),
+						Email: toStringPointer("email2@atlassian.com"),
+						Name:  toStringPointer("name2"),
+						Valid: toBoolPointer(true),
 					},
 				},
 			},
@@ -577,19 +577,19 @@ func TestGetPrivateIPsAtTimeMultiRowsM1Schema(t *testing.T) {
 			ARN:                "rid2",
 			Tags:               map[string]string{"bye": "now"},
 			AccountOwner: domain.AccountOwner{
-				AccountID: "aid2",
+				AccountID: toStringPointer("aid2"),
 				Owner: domain.Person{
-					Login: "login",
-					Email: "email@atlassian.com",
-					Name:  "name",
-					Valid: true,
+					Login: toStringPointer("login"),
+					Email: toStringPointer("email@atlassian.com"),
+					Name:  toStringPointer("name"),
+					Valid: toBoolPointer(true),
 				},
 				Champions: []domain.Person{
 					{
-						Login: "login2",
-						Email: "email2@atlassian.com",
-						Name:  "name2",
-						Valid: true,
+						Login: toStringPointer("login2"),
+						Email: toStringPointer("email2@atlassian.com"),
+						Name:  toStringPointer("name2"),
+						Valid: toBoolPointer(true),
 					},
 				},
 			},
@@ -684,19 +684,19 @@ func TestGetPublicIPsAtTimeMultiRowsM1Schema(t *testing.T) {
 			ARN:               "rid",
 			Tags:              map[string]string{"hi": "there"},
 			AccountOwner: domain.AccountOwner{
-				AccountID: "aid",
+				AccountID: toStringPointer("aid"),
 				Owner: domain.Person{
-					Login: "login",
-					Email: "email@atlassian.com",
-					Name:  "name",
-					Valid: true,
+					Login: toStringPointer("login"),
+					Email: toStringPointer("email@atlassian.com"),
+					Name:  toStringPointer("name"),
+					Valid: toBoolPointer(true),
 				},
 				Champions: []domain.Person{
 					{
-						Login: "login2",
-						Email: "email2@atlassian.com",
-						Name:  "name2",
-						Valid: true,
+						Login: toStringPointer("login2"),
+						Email: toStringPointer("email2@atlassian.com"),
+						Name:  toStringPointer("name2"),
+						Valid: toBoolPointer(true),
 					},
 				},
 			},
@@ -710,19 +710,19 @@ func TestGetPublicIPsAtTimeMultiRowsM1Schema(t *testing.T) {
 			ARN:               "rid2",
 			Tags:              map[string]string{"bye": "now"},
 			AccountOwner: domain.AccountOwner{
-				AccountID: "aid2",
+				AccountID: toStringPointer("aid2"),
 				Owner: domain.Person{
-					Login: "login",
-					Email: "email@atlassian.com",
-					Name:  "name",
-					Valid: true,
+					Login: toStringPointer("login"),
+					Email: toStringPointer("email@atlassian.com"),
+					Name:  toStringPointer("name"),
+					Valid: toBoolPointer(true),
 				},
 				Champions: []domain.Person{
 					{
-						Login: "login2",
-						Email: "email2@atlassian.com",
-						Name:  "name2",
-						Valid: true,
+						Login: toStringPointer("login2"),
+						Email: toStringPointer("email2@atlassian.com"),
+						Name:  toStringPointer("name2"),
+						Valid: toBoolPointer(true),
 					},
 				},
 			},
@@ -843,19 +843,19 @@ func TestGetHostnamesAtTimeSchema2(t *testing.T) {
 		ARN:               "rid",
 		Tags:              map[string]string{"hi": "there3"},
 		AccountOwner: domain.AccountOwner{
-			AccountID: "aid",
+			AccountID: toStringPointer("aid"),
 			Owner: domain.Person{
-				Login: "login",
-				Email: "email@atlassian.com",
-				Name:  "name",
-				Valid: true,
+				Login: toStringPointer("login"),
+				Email: toStringPointer("email@atlassian.com"),
+				Name:  toStringPointer("name"),
+				Valid: toBoolPointer(true),
 			},
 			Champions: []domain.Person{
 				{
-					Login: "login2",
-					Email: "email2@atlassian.com",
-					Name:  "name2",
-					Valid: true,
+					Login: toStringPointer("login2"),
+					Email: toStringPointer("email2@atlassian.com"),
+					Name:  toStringPointer("name2"),
+					Valid: toBoolPointer(true),
 				},
 			},
 		},
@@ -1007,19 +1007,19 @@ func TestGetHostnamesAtTimeMultiRowsSchema2(t *testing.T) {
 		ARN:                "rid",
 		Tags:               map[string]string{"hi": "there3"},
 		AccountOwner: domain.AccountOwner{
-			AccountID: "aid",
+			AccountID: toStringPointer("aid"),
 			Owner: domain.Person{
-				Login: "login",
-				Email: "email@atlassian.com",
-				Name:  "name",
-				Valid: true,
+				Login: toStringPointer("login"),
+				Email: toStringPointer("email@atlassian.com"),
+				Name:  toStringPointer("name"),
+				Valid: toBoolPointer(true),
 			},
 			Champions: []domain.Person{
 				{
-					Login: "login2",
-					Email: "email2@atlassian.com",
-					Name:  "name2",
-					Valid: true,
+					Login: toStringPointer("login2"),
+					Email: toStringPointer("email2@atlassian.com"),
+					Name:  toStringPointer("name2"),
+					Valid: toBoolPointer(true),
 				},
 			},
 		},
@@ -1130,19 +1130,19 @@ func TestGetARNIDAtTime(t *testing.T) {
 		ARN:                "arnid",
 		Tags:               map[string]string{"hi": "there3"},
 		AccountOwner: domain.AccountOwner{
-			AccountID: "aid",
+			AccountID: toStringPointer("aid"),
 			Owner: domain.Person{
-				Login: "login",
-				Email: "email@atlassian.com",
-				Name:  "name",
-				Valid: true,
+				Login: toStringPointer("login"),
+				Email: toStringPointer("email@atlassian.com"),
+				Name:  toStringPointer("name"),
+				Valid: toBoolPointer(true),
 			},
 			Champions: []domain.Person{
 				{
-					Login: "login2",
-					Email: "email2@atlassian.com",
-					Name:  "name2",
-					Valid: true,
+					Login: toStringPointer("login2"),
+					Email: toStringPointer("email2@atlassian.com"),
+					Name:  toStringPointer("name2"),
+					Valid: toBoolPointer(true),
 				},
 			},
 		},
@@ -1237,19 +1237,19 @@ func TestGetARNIDAtTimeMoreThanOnePublicIPs(t *testing.T) {
 			ARN:                "arnid",
 			Tags:               map[string]string{"hi": "there3"},
 			AccountOwner: domain.AccountOwner{
-				AccountID: "aid",
+				AccountID: toStringPointer("aid"),
 				Owner: domain.Person{
-					Name:  "name",
-					Login: "login",
-					Email: "email@atlassian.com",
-					Valid: true,
+					Name:  toStringPointer("name"),
+					Login: toStringPointer("login"),
+					Email: toStringPointer("email@atlassian.com"),
+					Valid: toBoolPointer(true),
 				},
 				Champions: []domain.Person{
 					{
-						Name:  "name2",
-						Login: "login2",
-						Email: "email2@atlassian.com",
-						Valid: true,
+						Name:  toStringPointer("name2"),
+						Login: toStringPointer("login2"),
+						Email: toStringPointer("email2@atlassian.com"),
+						Valid: toBoolPointer(true),
 					},
 				},
 			},
@@ -1337,7 +1337,7 @@ func TestGetARNIDAtTimeMoreThanOneChampions(t *testing.T) {
 	actual := results[0]
 
 	sort.SliceStable(actual.AccountOwner.Champions, func(i, j int) bool {
-		return actual.AccountOwner.Champions[i].Name < actual.AccountOwner.Champions[j].Name
+		return *actual.AccountOwner.Champions[i].Name < *actual.AccountOwner.Champions[j].Name
 	})
 
 	assert.Equal(t, 1, len(results))
@@ -1351,25 +1351,25 @@ func TestGetARNIDAtTimeMoreThanOneChampions(t *testing.T) {
 		ARN:                "arnid",
 		Tags:               map[string]string{"hi": "there3"},
 		AccountOwner: domain.AccountOwner{
-			AccountID: "aid",
+			AccountID: toStringPointer("aid"),
 			Owner: domain.Person{
-				Name:  "name",
-				Login: "login",
-				Email: "email@atlassian.com",
-				Valid: true,
+				Name:  toStringPointer("name"),
+				Login: toStringPointer("login"),
+				Email: toStringPointer("email@atlassian.com"),
+				Valid: toBoolPointer(true),
 			},
 			Champions: []domain.Person{
 				{
-					Name:  "name2",
-					Login: "login2",
-					Email: "email2@atlassian.com",
-					Valid: true,
+					Name:  toStringPointer("name2"),
+					Login: toStringPointer("login2"),
+					Email: toStringPointer("email2@atlassian.com"),
+					Valid: toBoolPointer(true),
 				},
 				{
-					Name:  "name3",
-					Login: "login3",
-					Email: "email3@atlassian.com",
-					Valid: true,
+					Name:  toStringPointer("name3"),
+					Login: toStringPointer("login3"),
+					Email: toStringPointer("email3@atlassian.com"),
+					Valid: toBoolPointer(true),
 				},
 			},
 		},
@@ -2052,8 +2052,8 @@ func TestStoreV2Assign(t *testing.T) {
 	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
 	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))              // nolint
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))                                         // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1))                            // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
 	mock.ExpectCommit()
 
@@ -2086,8 +2086,8 @@ func TestStoreV2Remove(t *testing.T) {
 	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
 	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))              // nolint
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))                                         // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1))                            // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
 	mock.ExpectCommit()
 
@@ -2342,19 +2342,19 @@ from aws_events_ips_hostnames as ae
 
 func fakeAccountOwnerInput() domain.AccountOwner {
 	return domain.AccountOwner{
-		AccountID: "awsaccountid123",
+		AccountID: toStringPointer("awsaccountid123"),
 		Owner: domain.Person{
-			Name:  "john dane",
-			Login: "jdane",
-			Email: "jdane@atlassian.com",
-			Valid: true,
+			Name:  toStringPointer("john dane"),
+			Login: toStringPointer("jdane"),
+			Email: toStringPointer("jdane@atlassian.com"),
+			Valid: toBoolPointer(true),
 		},
 		Champions: []domain.Person{
 			{
-				Name:  "john dane",
-				Login: "jdane",
-				Email: "jdane@atlassian.com",
-				Valid: true,
+				Name:  toStringPointer("john dane"),
+				Login: toStringPointer("jdane"),
+				Email: toStringPointer("jdane@atlassian.com"),
+				Valid: toBoolPointer(true),
 			},
 		},
 	}
@@ -2362,12 +2362,12 @@ func fakeAccountOwnerInput() domain.AccountOwner {
 
 func fakeAccountOwnerInputNoChampion() domain.AccountOwner {
 	return domain.AccountOwner{
-		AccountID: "awsaccountid123",
+		AccountID: toStringPointer("awsaccountid123"),
 		Owner: domain.Person{
-			Name:  "john dane",
-			Login: "jdane",
-			Email: "jdane@atlassian.com",
-			Valid: true,
+			Name:  toStringPointer("john dane"),
+			Login: toStringPointer("jdane"),
+			Email: toStringPointer("jdane@atlassian.com"),
+			Valid: toBoolPointer(true),
 		},
 	}
 }
@@ -2604,4 +2604,14 @@ func TestResIDFromARN(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Helper function to convert strings to pointers (for nullability)
+func toStringPointer(s string) *string {
+	return &s
+}
+
+// Helper function to convert booleans to pointers (for nullability)
+func toBoolPointer(b bool) *bool {
+	return &b
 }


### PR DESCRIPTION
Replaced inner joins with left joins so we do not return an empty set when there are no account owners. This was tested with schema version 12 and 13 with and without an account owner, and with and without champions. Both versions work with no champions, only 13 works with no account owner. Also needed to make some strings nullable because of the null fields that are now returned when there is no account owner. Did a little research, and it seems pointers are the easiest way to work with null strings returned by the sql library we are using.

This is my first time doing a migration, so let me know if this is incorrect!