### PR TITLE
SID-630 Add Integration Testing Against Master to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
   - make integration
   - make coverage
   - bash <(curl -s https://codecov.io/bash) -f .coverage/combined.cover.out
+  - make master-integration

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ integration: integration-app integration-test clean-integration
 # Run integration tests against master client and tests
 master-integration: clean-integration
 	git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+	git config core.filemode false
 	git fetch --depth=1 origin master
 	git diff origin/master -- api.yaml
 	git diff origin/master -- ./integration

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,6 @@ master-integration: clean-integration
 	git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 	git config core.filemode false
 	git fetch --depth=1 origin master
-	git diff origin/master -- api.yaml
-	git diff origin/master -- ./integration
 	IS_API_DIFF=$$(git diff --quiet origin/master -- api.yaml; echo $$?); \
 	IS_TEST_DIFF=$$(git diff --quiet origin/master -- ./integration; echo $$?); \
 	if [ $$IS_API_DIFF != 0 ] || [ $$IS_TEST_DIFF != 0 ]; then \
@@ -78,6 +76,8 @@ master-integration: clean-integration
 		git rm -rf integration; \
 		git checkout origin/master -- integration; \
 		make integration-test; \
+	else \
+		echo 'Skipping master integration testing: no changes to local API or tests'; \
 	fi
 
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,10 @@ integration: integration-app integration-test clean-integration
 master-integration: clean-integration
 	git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 	git fetch --depth=1 origin master
+	git diff origin/master -- api.yaml
+	git diff origin/master -- ./integration
 	IS_API_DIFF=$$(git diff --quiet origin/master -- api.yaml; echo $$?); \
 	IS_TEST_DIFF=$$(git diff --quiet origin/master -- ./integration; echo $$?); \
-	echo $$IS_API_DIFF; echo $$IS_TEST_DIFF; \
 	if [ $$IS_API_DIFF != 0 ] || [ $$IS_TEST_DIFF != 0 ]; then \
 		make integration-app; \
 		git checkout origin/master -- api.yaml; \

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ master-integration: clean-integration
 	git fetch --depth=1 origin master
 	$(eval isAPIDiff = $(shell git diff --quiet origin/master -- api.yaml; echo $$?))
 	$(eval isTestDiff = $(shell git diff --quiet origin/master -- ./integration; echo $$?))
-	if [[ $(isAPIDiff) != 0 || $(isTestDiff) != 0 ]]; then \
+	if [ $(isAPIDiff) != 0 ] || [ $(isTestDiff) != 0 ]; then \
   		make integration-app; \
 		git checkout origin/master -- api.yaml; \
 		git rm -rf integration; \

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,15 @@ integration: integration-app integration-test clean-integration
 master-integration: clean-integration
 	git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 	git fetch --depth=1 origin master
-	make integration-app
-	git checkout origin/master -- api.yaml
-	git rm -rf integration
-	git checkout origin/master -- integration
-	make integration-test
+	$(eval isAPIDiff = $(shell git diff --quiet origin/master -- api.yaml; echo $$?))
+	$(eval isTestDiff = $(shell git diff --quiet origin/master -- ./integration; echo $$?))
+	if [[ $(isAPIDiff) != 0 || $(isTestDiff) != 0 ]]; then \
+  		make integration-app; \
+		git checkout origin/master -- api.yaml; \
+		git rm -rf integration; \
+		git checkout origin/master -- integration; \
+		make integration-test; \
+	fi
 
 coverage:
 	docker run -ti \

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ integration: integration-app integration-test clean-integration
 master-integration: clean-integration
 	git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 	git fetch --depth=1 origin master
+	git branch -a
 	$(eval isAPIDiff = $(shell git diff --quiet origin/master -- api.yaml; echo $$?))
 	$(eval isTestDiff = $(shell git diff --quiet origin/master -- ./integration; echo $$?))
 	if [ $(isAPIDiff) != 0 ] || [ $(isTestDiff) != 0 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ integration: integration-app integration-test clean-integration
 master-integration: clean-integration
 	git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 	git fetch --depth=1 origin master
-	$(eval isAPIDiff = $(shell git diff --quiet origin/master -- api.yaml; echo $$?))
-	$(eval isTestDiff = $(shell git diff --quiet origin/master -- ./integration; echo $$?))
+	$(eval isAPIDiff = $(shell git diff --quiet master -- api.yaml; echo $$?))
+	$(eval isTestDiff = $(shell git diff --quiet master -- ./integration; echo $$?))
 	if [ $(isAPIDiff) != 0 ] || [ $(isTestDiff) != 0 ]; then \
   		make integration-app; \
 		git checkout origin/master -- api.yaml; \

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ integration: integration-app integration-test clean-integration
 master-integration: clean-integration
 	git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 	git fetch --depth=1 origin master
-	$(eval isAPIDiff = $(shell git diff --quiet master -- api.yaml; echo $$?))
-	$(eval isTestDiff = $(shell git diff --quiet master -- ./integration; echo $$?))
+	$(eval isAPIDiff = $(shell git diff --quiet origin/master -- api.yaml; echo $$?))
+	$(eval isTestDiff = $(shell git diff --quiet origin/master -- ./integration; echo $$?))
 	if [ $(isAPIDiff) != 0 ] || [ $(isTestDiff) != 0 ]; then \
   		make integration-app; \
 		git checkout origin/master -- api.yaml; \

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ master-integration: clean-integration
 	git fetch --depth=1 origin master
 	IS_API_DIFF=$$(git diff --quiet origin/master -- api.yaml; echo $$?); \
 	IS_TEST_DIFF=$$(git diff --quiet origin/master -- ./integration; echo $$?); \
+	echo $$IS_API_DIFF; echo $$IS_TEST_DIFF; \
 	if [ $$IS_API_DIFF != 0 ] || [ $$IS_TEST_DIFF != 0 ]; then \
 		make integration-app; \
 		git checkout origin/master -- api.yaml; \

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,10 @@ integration: integration-app integration-test clean-integration
 master-integration: clean-integration
 	git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 	git fetch --depth=1 origin master
-	git branch -a
-	$(eval isAPIDiff = $(shell git diff --quiet origin/master -- api.yaml; echo $$?))
-	$(eval isTestDiff = $(shell git diff --quiet origin/master -- ./integration; echo $$?))
-	if [ $(isAPIDiff) != 0 ] || [ $(isTestDiff) != 0 ]; then \
-  		make integration-app; \
+	IS_API_DIFF=$$(git diff --quiet origin/master -- api.yaml; echo $$?); \
+	IS_TEST_DIFF=$$(git diff --quiet origin/master -- ./integration; echo $$?); \
+	if [ $$IS_API_DIFF != 0 ] || [ $$IS_TEST_DIFF != 0 ]; then \
+		make integration-app; \
 		git checkout origin/master -- api.yaml; \
 		git rm -rf integration; \
 		git checkout origin/master -- integration; \

--- a/integration/tests/client_test.go
+++ b/integration/tests/client_test.go
@@ -32,7 +32,7 @@ func TestHealthcheck(t *testing.T) {
 			Name string
 		}{
 			{
-				Name: "Health Check",
+				Name: "Health Check -- Testing with test change",
 			},
 		}
 		for _, test := range tt {

--- a/integration/tests/client_test.go
+++ b/integration/tests/client_test.go
@@ -32,7 +32,7 @@ func TestHealthcheck(t *testing.T) {
 			Name string
 		}{
 			{
-				Name: "Health Check -- Testing with test change",
+				Name: "Health Check",
 			},
 		}
 		for _, test := range tt {

--- a/integration/tests/client_test.go
+++ b/integration/tests/client_test.go
@@ -32,7 +32,7 @@ func TestHealthcheck(t *testing.T) {
 			Name string
 		}{
 			{
-				Name: "Health Check -- testing",
+				Name: "Health Check",
 			},
 		}
 		for _, test := range tt {

--- a/integration/tests/client_test.go
+++ b/integration/tests/client_test.go
@@ -32,7 +32,7 @@ func TestHealthcheck(t *testing.T) {
 			Name string
 		}{
 			{
-				Name: "Health Check",
+				Name: "Health Check -- testing",
 			},
 		}
 		for _, test := range tt {


### PR DESCRIPTION
Added testing against master as the last step of the CI. This will only run if there are changes either to the API (api.yaml) or to the tests in the current branch. 