### PR TITLE
Hotfix as Index can not be dropped concurrently in transaction

### DIFF
--- a/db-migrations/000012_adding_indexes_on_aws_resource_relationship.down.sql
+++ b/db-migrations/000012_adding_indexes_on_aws_resource_relationship.down.sql
@@ -1,7 +1,3 @@
 -- Removing indexes on aws_resource_relationship
-BEGIN;
-
 DROP INDEX CONCURRENTLY IF EXISTS aws_resource_relationship_idx_no_after;
 DROP INDEX CONCURRENTLY IF EXISTS aws_resource_relationship_idx_no_before;
-
-COMMIT;


### PR DESCRIPTION
### Overview
* On schema down we see following error 
`ERROR:  DROP INDEX CONCURRENTLY cannot run inside a transaction block`
* This hot fix is to address the issue