### PR TITLE
Update releasePrivateIp

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -1034,7 +1034,8 @@ func (db *DB) releasePrivateIP(ctx context.Context, tx *sql.Tx, arnID string, ip
 update aws_private_ip_assignment
 set not_after=$1
 where private_ip = $2
-  and aws_resource_id = (select id from aws_resource where arn_id = $3);`
+  and aws_resource_id = (select id from aws_resource where arn_id = $3)
+  and not_after is null ;`
 
 	const releasePrivateIPQueryInsert = `
 insert into aws_private_ip_assignment


### PR DESCRIPTION
The update statement for `releasePrivateIp()` did not expect multiple records to exist in `aws_private_ip_assignment` with the same `private_ip` _and_ `aws_resource_id` and therefore updated all records that matched only on these two criteria. Now that we have seen these multiple events occur in prod, while we cannot guarantee that events will be processed in order, IF they are then the update statement will apply only to the most recent record `where not_after is null` so that it will not update all records with the same `not_after` timestamp.