### PR TITLE
Add validation for aws account input

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -784,7 +784,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AccountOwner"
+              $ref: "#/components/schemas/SetAccountOwner"
       responses:
         201:
           description: "An AWS account with its owner and champions are inserted or updated"
@@ -987,6 +987,39 @@ components:
           type: string
         valid:
           type: boolean
+    SetAccountOwner:
+      type: object
+      properties:
+        accountId:
+          type: string
+          pattern: ^(\d{12})$
+        name:
+          type: string
+        owner:
+          $ref: "#/components/schemas/SetPerson"
+        champions:
+          type: array
+          items:
+            $ref: "#/components/schemas/SetPerson"
+      required:
+        - accountId
+        - owner
+    SetPerson:
+      type: object
+      properties:
+        name:
+          type: string
+        login:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          pattern: ^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$
+        valid:
+          type: boolean
+      required:
+        - login
+        - email
     Error:
       type: object
       properties:

--- a/api.yaml
+++ b/api.yaml
@@ -993,8 +993,6 @@ components:
         accountId:
           type: string
           pattern: ^(\d{12})$
-        name:
-          type: string
         owner:
           $ref: "#/components/schemas/SetPerson"
         champions:


### PR DESCRIPTION
Added a separate object schema to validate input of owners and champions (there is a ticket to re-combine when we are ready).

I would love any input on whether this is too strict, or even too loose. 

This has been tested locally, we have a ticket to address integration testing on this endpoint.

I will need to followup with updating api.yaml on BB as well.