### PR TITLE
updating min schema version to be current

### DIFF
--- a/integration/tests/client_test.go
+++ b/integration/tests/client_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var assetInventoryAPI *openapi.APIClient
-var schemaVersion int32 = 14
+var schemaVersion int32 = 13
 var maxSchema int32 = 14 // TODO: extrapolate this somewhere?
 
 func TestMain(m *testing.M) {

--- a/integration/tests/client_test.go
+++ b/integration/tests/client_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 var assetInventoryAPI *openapi.APIClient
-var schemaVersion int32 = 1
-var maxSchema int32 = 13 // TODO: extrapolate this somewhere?
+var schemaVersion int32 = 14
+var maxSchema int32 = 14 // TODO: extrapolate this somewhere?
 
 func TestMain(m *testing.M) {
 	config := openapi.NewConfiguration()

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -29,7 +29,7 @@ const (
 	// NewSchemaOnlyVersion Lowest version that stops dual-writes in preparation to drop old schema
 	NewSchemaOnlyVersion uint = 6
 	// MinimumSchemaVersion Lowest version of the database schema that functions with the current code
-	MinimumSchemaVersion uint = 14
+	MinimumSchemaVersion uint = 13
 )
 
 // SchemaManager is an abstraction layer for manipulating database schema backed by golang/migrate

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -20,8 +20,6 @@ const (
 const (
 	// EmptySchemaVersion Version of database schema that cleans the database completely. Use cautiously!
 	EmptySchemaVersion uint = 0
-	// MinimumSchemaVersion Lowest version of database schema current code is able to handle
-	MinimumSchemaVersion uint = 1
 	// M1SchemaVersion Version of database schema with performance optimizations (M1) that allows back-fill to work
 	M1SchemaVersion uint = 2
 	// DualWritesSchemaVersion Lowest version of database schema that supports dual-writes (legacy and M1)
@@ -30,6 +28,8 @@ const (
 	ReadsFromNewSchemaVersion uint = 4
 	// NewSchemaOnlyVersion Lowest version that stops dual-writes in preparation to drop old schema
 	NewSchemaOnlyVersion uint = 6
+	// MinimumSchemaVersion Lowest version of the database schema that functions with the current code
+	MinimumSchemaVersion uint = 14
 )
 
 // SchemaManager is an abstraction layer for manipulating database schema backed by golang/migrate


### PR DESCRIPTION
As explained in our runbook, the minimum default schema version should be updated after a new version has been successfully deployed and migrated.