### PR TITLE
Adding integration test for hostname and some refactoring

### DIFF
--- a/integration/tests/lookup_by_hostname_test.go
+++ b/integration/tests/lookup_by_hostname_test.go
@@ -5,62 +5,57 @@ package tests
 import (
 	"context"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-//TODO add tests for resource IDs containing slashes, tracked in separate ticket
-
-func TestLookupByResourceID(t *testing.T) {
+func TestLookupByHostname(t *testing.T) {
 	ctx := context.Background()
 	chgAssign, chgRemove, api := Setup(t, ctx)
-	// extract resource ID
-	spl := strings.Split(chgAssign.Arn, "/") // this will need separate handling (helper func? for things like ELB)
-	resId := spl[len(spl)-1]
+	// extract hostname
+	hostname := chgAssign.Changes[0].Hostnames[0]
 
 	tsDuring := chgAssign.ChangeTime.Add(1 * time.Second)
 	tsBefore := chgAssign.ChangeTime.Add(-1 * time.Second) // nb .Sub does something very different :confused:
 	tsAfter := chgRemove.ChangeTime.Add(1 * time.Second)
 
 	testCases := map[string]struct {
-		resourceID string
-		ts         time.Time
-		httpCode   int
-		mustError  bool
+		hostname  string
+		ts        time.Time
+		httpCode  int
+		mustError bool
 	}{
 		"Valid": { // ideally we'd have response validation for happy path here, but the test for cloudchanges does it
-			resId,
+			hostname,
 			tsDuring,
 			http.StatusOK,
 			false,
 		},
 		"TSBefore": {
-			resId,
+			hostname,
 			tsBefore,
 			http.StatusNotFound,
 			true, // openapi bindings treat 404 as error
 		},
 		"TSAfter": {
-			resId,
+			hostname,
 			tsAfter,
 			http.StatusNotFound,
 			true, // openapi bindings treat 404 as error
 		},
-		"ResIDEmpty": {
+		"HostnameEmpty": {
 			"",
 			tsDuring,
 			http.StatusBadRequest,
 			true,
 		},
-		//TODO find a way to inject invalid timestamp
 	}
 	for name, tc := range testCases {
 		t.Run(addSchemaVersion(name),
 			func(t *testing.T) {
-				_, httpRes, err := api.V1CloudResourceidResourceidGet(ctx, tc.resourceID, tc.ts)
+				_, httpRes, err := api.V1CloudHostnameHostnameGet(ctx, tc.hostname, tc.ts)
 				if tc.mustError {
 					assert.Error(t, err)
 				} else {
@@ -70,5 +65,7 @@ func TestLookupByResourceID(t *testing.T) {
 			})
 	}
 
-	RawUrlFollowupTests(t, "/v1/cloud/resourceid/" + resId, tsDuring)
+	RawUrlFollowupTests(t, "/v1/cloud/hostname/" + hostname, tsDuring)
 }
+
+

--- a/integration/tests/main_test.go
+++ b/integration/tests/main_test.go
@@ -5,8 +5,13 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
+	"path"
 	"testing"
+	"time"
+	"github.com/stretchr/testify/assert"
 
 	openapi "github.com/asecurityteam/asset-inventory-api/client"
 )
@@ -38,4 +43,113 @@ func TestMain(m *testing.M) {
 		res += m.Run()
 	}
 	os.Exit(res) //non-zero if any of the fixtures failed
+}
+
+func Setup(t *testing.T, ctx context.Context) (openapi.CloudAssetChanges, openapi.CloudAssetChanges, *openapi.DefaultApiService) {
+	// ensure the Asset has something assigned so that we can find it
+	chgAssign := SampleAssetChanges()
+	// create the matching delete changes so that we can check AFTER the assignment time
+	chgRemove := SampleAssetChanges()
+	chgRemove.Changes[0].ChangeType = "DELETED"
+	chgRemove.ChangeTime = chgRemove.ChangeTime.Add(24 * time.Hour)
+	// shortcut to defaultApi
+	api := assetInventoryAPI.DefaultApi
+	// add change events
+	for _, chg := range []openapi.CloudAssetChanges{chgAssign, chgRemove} {
+		_, err := api.V1CloudChangePost(ctx, chg)
+		if err != nil {
+			t.Errorf("error publishing sample change: %#v", err)
+		}
+	}
+	return chgAssign, chgRemove, api
+}
+
+func RawUrlFollowupTests(t *testing.T, suffixPath string, tsDuring time.Time) {
+	// subsequent tests can not be driven by the same table as we must call http directly
+	// because swagger bindings do not allow to mess with invalid/missing time values or arbitrary arguments
+	endpoint, err := url.Parse(assetInventoryAPI.GetConfig().BasePath)
+	if err != nil {
+		t.Fatalf("unable to parse base path for direct calls #%v", err)
+	}
+	// construct a complete valid URL for raw tests to start off with
+	endpoint.Path = path.Join(endpoint.Path, suffixPath)
+	q := endpoint.Query()
+	q.Add("time", tsDuring.Format(time.RFC3339Nano))
+	endpoint.RawQuery = q.Encode()
+
+	rawHttp := http.Client{
+		Timeout: 500 * time.Millisecond,
+	}
+
+	rawTestCases := map[string]struct {
+		urlProcessor func(url.URL) url.URL //pass by value!
+		httpCode     int
+		mustError    bool // unlike openapi, http client does not set err for 404 or 400
+	}{
+		"RawRequestValid": { // this one is to test the raw test, to make sure we can get 200 over raw connection
+			func(u url.URL) url.URL {
+				return u // do nothing, send valid request
+			},
+			http.StatusOK,
+			false,
+		},
+		"TimestampMissing": {
+			func(u url.URL) url.URL {
+				q := u.Query()
+				q.Del("time")
+				u.RawQuery = q.Encode()
+				return u
+			},
+			http.StatusBadRequest,
+			false,
+		},
+		"TimestampMalformed": {
+			func(u url.URL) url.URL {
+				q := u.Query()
+				q.Del("time")
+				q.Add("time", "somewhere in time and not valid at all")
+				u.RawQuery = q.Encode()
+				return u
+			},
+			http.StatusBadRequest,
+			false,
+		},
+		"TimestampDuplicatedMalformed": {
+			func(u url.URL) url.URL { //this results in two different timestamp= values, one being malformed
+				q := u.Query()
+				q.Add("time", "somewhere in time and not valid at all")
+				u.RawQuery = q.Encode()
+				return u
+			},
+			http.StatusOK, //FIXME this should be StatusBadRequest, as we should not shop around for valid values
+			false,
+		},
+		"UnknownQueryArgument": {
+			func(u url.URL) url.URL {
+				q := u.Query()
+				q.Add("rogue", "totally useless and not part of api definition")
+				u.RawQuery = q.Encode()
+				return u
+			},
+			http.StatusOK, //FIXME this should be StatusBadRequest, the unexpected args == typo/error
+			false,
+		},
+	}
+
+	for name, tc := range rawTestCases {
+		t.Run(addSchemaVersion(name), func(t *testing.T) {
+			rawUrl := tc.urlProcessor(*endpoint)
+			req, err := http.NewRequest("GET", rawUrl.String(), nil)
+			if err != nil {
+				t.Fatalf("unable to initialize request for direct call #%v", err)
+			}
+			res, err := rawHttp.Do(req)
+			if tc.mustError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.httpCode, res.StatusCode)
+		})
+	}
 }


### PR DESCRIPTION
### Overview
* Adding integration tests for `/v1/cloud/hostname` API
* Most of the implementation is similar to `/v1/cloud/resourceid/` API tests, hence performed some refactoring to reuse code 