### PR TITLE
Removing related resources from GET endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -907,10 +907,6 @@ components:
           type: array
           items:
             type: string
-        relatedResources:
-          type: array
-          items:
-            type: string
         resourceType:
           type: string
         accountId:


### PR DESCRIPTION
RR should not be included in the object that we return for GET requests.