### PR TITLE
Fix transaction getting poisoned

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -416,50 +416,7 @@ func (db *DB) StoreV2(ctx context.Context, cloudAssetChanges domain.CloudAssetCh
 		return err
 	}
 	if err = db.ensureResourceExists(ctx, cloudAssetChanges, tx); err == nil {
-		arnID := resIDFromARN(cloudAssetChanges.ARN)
-		for _, val := range cloudAssetChanges.Changes {
-			for _, ip := range val.PrivateIPAddresses {
-				if strings.EqualFold(added, val.ChangeType) {
-					err = db.assignPrivateIP(ctx, tx, arnID, ip, cloudAssetChanges.ChangeTime)
-				} else {
-					err = db.releasePrivateIP(ctx, tx, arnID, ip, cloudAssetChanges.ChangeTime)
-				}
-				if err != nil {
-					break
-				}
-			}
-			if err != nil {
-				break
-			}
-			for _, ip := range val.PublicIPAddresses {
-				for _, hostname := range val.Hostnames { //TODO look very closely into awsconfig-tranformerd logic for this
-					if strings.EqualFold(added, val.ChangeType) {
-						err = db.assignPublicIP(ctx, tx, arnID, ip, hostname, cloudAssetChanges.ChangeTime)
-					} else {
-						err = db.releasePublicIP(ctx, tx, arnID, ip, hostname, cloudAssetChanges.ChangeTime)
-					}
-					if err != nil {
-						break
-					}
-				}
-			}
-			if err != nil {
-				break
-			}
-			for _, res := range val.RelatedResources {
-				if strings.EqualFold(added, val.ChangeType) {
-					err = db.assignResourceRelationship(ctx, tx, arnID, res, cloudAssetChanges.ChangeTime)
-				} else {
-					err = db.releaseResourceRelationship(ctx, tx, arnID, res, cloudAssetChanges.ChangeTime)
-				}
-				if err != nil {
-					break
-				}
-			}
-			if err != nil {
-				break
-			}
-		}
+		err = db.applyChanges(ctx, cloudAssetChanges, tx)
 	}
 	if err != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
@@ -469,6 +426,46 @@ func (db *DB) StoreV2(ctx context.Context, cloudAssetChanges domain.CloudAssetCh
 	}
 	if err = tx.Commit(); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (db *DB) applyChanges(ctx context.Context, cloudAssetChanges domain.CloudAssetChanges, tx *sql.Tx) error {
+	var err error
+	arnID := resIDFromARN(cloudAssetChanges.ARN)
+	for _, val := range cloudAssetChanges.Changes {
+		for _, ip := range val.PrivateIPAddresses {
+			if strings.EqualFold(added, val.ChangeType) {
+				err = db.assignPrivateIP(ctx, tx, arnID, ip, cloudAssetChanges.ChangeTime)
+			} else {
+				err = db.releasePrivateIP(ctx, tx, arnID, ip, cloudAssetChanges.ChangeTime)
+			}
+			if err != nil {
+				return err
+			}
+		}
+		for _, ip := range val.PublicIPAddresses {
+			for _, hostname := range val.Hostnames { //TODO look very closely into awsconfig-tranformerd logic for this
+				if strings.EqualFold(added, val.ChangeType) {
+					err = db.assignPublicIP(ctx, tx, arnID, ip, hostname, cloudAssetChanges.ChangeTime)
+				} else {
+					err = db.releasePublicIP(ctx, tx, arnID, ip, hostname, cloudAssetChanges.ChangeTime)
+				}
+				if err != nil {
+					return err
+				}
+			}
+		}
+		for _, res := range val.RelatedResources {
+			if strings.EqualFold(added, val.ChangeType) {
+				err = db.assignResourceRelationship(ctx, tx, arnID, res, cloudAssetChanges.ChangeTime)
+			} else {
+				err = db.releaseResourceRelationship(ctx, tx, arnID, res, cloudAssetChanges.ChangeTime)
+			}
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -428,6 +428,9 @@ func (db *DB) StoreV2(ctx context.Context, cloudAssetChanges domain.CloudAssetCh
 					break
 				}
 			}
+			if err != nil {
+				break
+			}
 			for _, ip := range val.PublicIPAddresses {
 				for _, hostname := range val.Hostnames { //TODO look very closely into awsconfig-tranformerd logic for this
 					if strings.EqualFold(added, val.ChangeType) {
@@ -435,7 +438,13 @@ func (db *DB) StoreV2(ctx context.Context, cloudAssetChanges domain.CloudAssetCh
 					} else {
 						err = db.releasePublicIP(ctx, tx, arnID, ip, hostname, cloudAssetChanges.ChangeTime)
 					}
+					if err != nil {
+						break
+					}
 				}
+			}
+			if err != nil {
+				break
 			}
 			for _, res := range val.RelatedResources {
 				if strings.EqualFold(added, val.ChangeType) {

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -2185,6 +2185,9 @@ func TestStoreV2FailResourceRelationship(t *testing.T) {
 	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
 	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
+	// Note: All related changes must be successful otherwise the whole transaction is cancelled
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))              // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnError(errors.New("failed to store relationship"))
 	mock.ExpectRollback()
 

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -2185,7 +2185,7 @@ func TestStoreV2FailResourceRelationship(t *testing.T) {
 	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
 	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
-	// Note: All related changes must be successful otherwise the whole transaction is cancelled
+	// Note: All related changes must be successful otherwise the whole transaction is canceled
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))              // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnError(errors.New("failed to store relationship"))


### PR DESCRIPTION
Ensuring that when an error happens for a cloud change POST we return an error right away so that the transaction isn't hanging around with an error causing subsequent queries to fail. This does mean that if any sql query fails on a request the whole request fails. 

Note: This was not and will not be poisoning following requests. The problem was with queries in the same transaction. When one query fails and breaks the transaction, the following queries in the transaction cannot run properly and we get a bunch of error logs. Not dire, but not ideal either.

I tried to find a way to write an integration test to make sure this fails gracefully, but luckily I couldn't find a way to replicate this problem with all of our new validations.

 (Also lint doesn't like "cancelled" as a spelling)