### PR TITLE
Add limit to number of hostname sent

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -753,6 +753,7 @@ components:
           type: array
           items:
             type: string
+          maxItems: 1
         resourceType:
           type: string
         accountId:

--- a/api.yaml
+++ b/api.yaml
@@ -704,6 +704,7 @@ components:
           type: array
           items:
             type: string
+          maxItems: 1
         relatedResources:
           type: array
           items:

--- a/integration/tests/sample_data_test.go
+++ b/integration/tests/sample_data_test.go
@@ -18,11 +18,9 @@ func SampleAssetChange() openapi.CloudAssetChange {
 	return openapi.CloudAssetChange{
 		PrivateIpAddresses: []string{"10.0.0.1", "10.0.0.2"},
 		PublicIpAddresses:  []string{"8.8.8.8", "8.8.4.4"},
-		//even though Hostnames is a list, there can be only one of them.
-		//TODO - reflect in schema in api.yaml that we do not accept more than one hostname
-		Hostnames:        []string{"myhostname.us-west-1.amazonaws.com"},
-		RelatedResources: []string{},
-		ChangeType:       "ADDED",
+		Hostnames:          []string{"myhostname.us-west-1.amazonaws.com"},
+		RelatedResources:   []string{},
+		ChangeType:         "ADDED",
 	}
 }
 


### PR DESCRIPTION
Schema is changed to set maximum number of hostname in array to 1. If more than one hostnames is sent, request will fail and an error message will be returned. 

{"changes":[{"privateIpAddresses":["10.0.0.1","10.0.0.2"],"publicIpAddresses":["8.8.8.8","8.8.4.4"],"hostnames":["myhostname.us-west-1.amazonaws.com","anotherhostname.com"],"changeType":"DELETED"}],"changeTime":"2018-01-13T22:51:48.324359102Z","resourceType":"AWS:EC2:Instance","accountId":"012345678901","region":"us-west-1","arn":"arn:aws:ec2:us-west-1:012345678901:instance/i-0123456789abcdef0","tags":{"Name":"ValidInstance","resource_owner":"jsmith"}}
test_1      |
test_1      | 2020/09/15 21:05:41
test_1      | HTTP/1.1 400 Bad Request
test_1      | Content-Length: 378
test_1      | Content-Type: application/json
test_1      | Date: Tue, 15 Sep 2020 21:05:41 GMT
test_1      |
test_1      | {"code":400,"status":"Bad Request","reason":"Request body has an error: doesn't match the schema: Error at "/changes/0/hostnames":Maximum number of items is 1\nSchema:\n  {\n    "items": {\n      "type": "string"\n    },\n    "maxItems": 1,\n    "type": "array"\n  }\n\nValue:\n  [\n    "myhostname.us-west-1.amazonaws.com",\n    "anotherhostname.com"\n  ]\n"}