### PR TITLE
Allow multiple arn id, as long as the region and/or owners are different.

### DIFF
--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -1192,10 +1192,14 @@ func TestStoreV2Assign(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
-	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
+	row := sqlmock.NewRows([]string{
+		"id",
+	}).AddRow(1)
+	mock.ExpectQuery("SELECT").WithArgs("arn", "aid", "region").WillReturnRows(row)
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))                                         // nolint
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1))                            // nolint
+	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", 1).WillReturnResult(sqlmock.NewResult(1, 1))                                             // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", 1, "google.com").WillReturnResult(sqlmock.NewResult(1, 1))                                // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
 	mock.ExpectCommit()
 
@@ -1226,10 +1230,14 @@ func TestStoreV2Remove(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
+	row := sqlmock.NewRows([]string{
+		"id",
+	}).AddRow(1)
+	mock.ExpectQuery("SELECT").WithArgs("arn", "aid", "region").WillReturnRows(row)
 	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))                                         // nolint
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1))                            // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", 1).WillReturnResult(sqlmock.NewResult(1, 1))                                             // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", 1, "google.com").WillReturnResult(sqlmock.NewResult(1, 1))                                // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
 	mock.ExpectCommit()
 
@@ -1260,9 +1268,13 @@ func TestStoreV2FailPrivate(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
+	row := sqlmock.NewRows([]string{
+		"id",
+	}).AddRow(1)
+	mock.ExpectQuery("SELECT").WithArgs("arn", "aid", "region").WillReturnRows(row)
 	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnError(errors.New("failed to store assignment"))
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", 1).WillReturnError(errors.New("failed to store assignment"))
 	mock.ExpectRollback()
 
 	ctx := context.Background()
@@ -1292,10 +1304,14 @@ func TestStoreV2FailPublic(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
+	row := sqlmock.NewRows([]string{
+		"id",
+	}).AddRow(1)
+	mock.ExpectQuery("SELECT").WithArgs("arn", "aid", "region").WillReturnRows(row)
 	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))                              // nolint
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnError(errors.New("failed to store assignment")) // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", 1).WillReturnResult(sqlmock.NewResult(1, 1))                              // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", 1, "google.com").WillReturnError(errors.New("failed to store assignment")) // nolint
 	mock.ExpectRollback()
 
 	ctx := context.Background()
@@ -1325,11 +1341,15 @@ func TestStoreV2FailResourceRelationship(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("with sel as").WithArgs("arn", "region", "aid", "rtype", []byte("{\"tag1\":\"val1\"}")).WillReturnResult(sqlmock.NewResult(1, 1))
+	row := sqlmock.NewRows([]string{
+		"id",
+	}).AddRow(1)
+	mock.ExpectQuery("SELECT").WithArgs("arn", "aid", "region").WillReturnRows(row)
 	timestamp, _ := time.Parse(time.RFC3339, "2019-04-09T08:29:35+00:00")
 	// NB we need to escape '$' and other special chars as the value passed as expected query is a regexp
 	// Note: All related changes must be successful otherwise the whole transaction is canceled
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", "arn").WillReturnResult(sqlmock.NewResult(1, 1))              // nolint
-	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", "arn", "google.com").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_private_ip_assignment`)).WithArgs(timestamp, "4.3.2.1", 1).WillReturnResult(sqlmock.NewResult(1, 1))              // nolint
+	mock.ExpectExec(regexp.QuoteMeta(`update aws_public_ip_assignment`)).WithArgs(timestamp, "8.7.6.5", 1, "google.com").WillReturnResult(sqlmock.NewResult(1, 1)) // nolint
 	mock.ExpectExec(regexp.QuoteMeta(`update aws_resource_relationship`)).WithArgs(timestamp, "app/marketp-ALB-eeeeeee5555555/ffffffff66666666", "arn").WillReturnError(errors.New("failed to store relationship"))
 	mock.ExpectRollback()
 


### PR DESCRIPTION
Two things this PR doesn't change:
1. Relationship arnid use
2. Returning multiple assets for the resource id lookup

About #2: We hadn't fully discussed whether we want to be able to return multiple assets for a resource id lookup. If we want this I can add to another PR. Something to note -- when I make this change locally we return over 3000 records for our "Valid" test because we use the same timestamps for many entries and multiple owner/champion combos. I assume this wouldn't be the case in real life, but if this is a concern I can also address this in another ticket.