### PR TITLE
Adding back codecov step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - travis_retry make dep
   - make lint
   - make test
-  - make integration
   - make coverage
   - bash <(curl -s https://codecov.io/bash) -f .coverage/combined.cover.out
+  - make integration
   - make master-integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ install:
   - chmod 777 -R "$(pwd)"
 script:
   - travis_retry make dep
+  - make test
   - make coverage
   - bash <(curl -s https://codecov.io/bash) -f .coverage/combined.cover.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,5 @@ install:
   - chmod 777 -R "$(pwd)"
 script:
   - travis_retry make dep
-  - make lint
-  - make test
   - make coverage
   - bash <(curl -s https://codecov.io/bash) -f .coverage/combined.cover.out
-  - make integration
-  - make master-integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ script:
   - make test
   - make integration
   - make coverage
-  # - bash <(curl -s https://codecov.io/bash) -f .coverage/combined.cover.out
+  - bash <(curl -s https://codecov.io/bash) -f .coverage/combined.cover.out
   - make master-integration

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,6 @@ coverage:
         informational: false
         only_pulls: false
     patch: off
-
 ignore:
   - "*.yml"
   - "*.sh"

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,8 @@ coverage:
     patch: off
 ignore:
   - "*.yml"
+  - "*.yaml"
+  - "*.md"
   - "*.sh"
   - "go.mod"
   - "go.sum"
@@ -23,3 +25,90 @@ ignore:
   - "*.Dockerfile"
   - "integration/*"
   - "integration/**/*"
+
+
+fgdbhskjgh
+fdbkjfdsgbk
+bkjhbk
+
+
+fbklfbglkds
+
+
+fbkfbdksf
+
+
+fbdskjfbvk
+fdbkjfdsgbkbfjksdb
+
+bfajkd
+bjbdas
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+
+bfajkd
+bjbdas
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+
+bfajkd
+bjbdas
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+
+bfajkd
+bjbdas
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+
+bfajkd
+bjbdas
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+bjbdv
+
+


### PR DESCRIPTION
Adding back the codecov step now we have a working ignore. I also moved it up before the integration tests as we would prefer to have it fail fast if code is lacking in coverage.