### PR TITLE
Sid 654/multiple resource params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,17 @@ test:
 psql-console:
 	docker-compose exec -u postgres postgres psql -U user assetmgmt
 
+# Preprocess our api.yaml to expand anchors. Our generation client does not understand anchors
+expand-yaml-anchors:
+	docker run --rm \
+		-v ${PWD}:/local python:3 /bin/bash -c \
+		"pip install pyyaml && python ./local/tools/expand-anchors.py ./local/api.yaml ./local/expanded.yaml"
+
 # Generate the client used for integration tests. For local development.
-generate-integration-client:
+generate-integration-client: expand-yaml-anchors
 	docker run --rm \
     	-v ${PWD}:/local openapitools/openapi-generator-cli:v5.0.0-beta generate \
-    	-i /local/api.yaml \
+    	-i /local/expanded.yaml \
     	-g go \
     	--git-user-id asecurityteam \
     	--git-repo-id asset-inventory-api/client \

--- a/api.yaml
+++ b/api.yaml
@@ -461,6 +461,80 @@ paths:
               #! end !#
               "bodyPassthrough": true
             }
+  /v1/cloud/resourceid/{r1}/{r2}/{r3}:
+    get:
+      summary: "Retrieve a cloud asset at a point in time by resource ID"
+      parameters:
+        - name: "r1"
+          in: "path"
+          description: "The resource id of the asset"
+          required: true
+          schema:
+            type: "string"
+        - name: "r2"
+          in: "path"
+          description: "The resource id of the asset pt 2"
+          required: true
+          schema:
+            type: "string"
+        - name: "r3"
+          in: "path"
+          description: "The resource id of the asset pt 3"
+          required: true
+          schema:
+            type: "string"
+        - name: "time"
+          in: "query"
+          description: "The point in time details for a given asset"
+          required: true
+          schema:
+            type: "string"
+            format: "date-time" # RFC3339Nano format
+      responses:
+        200:
+          description: "List of all assets found with the resource ID at the given time"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CloudAssets"
+        400:
+          description: "Invalid input"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        404:
+          description: "The asset is not found"
+      x-transportd:
+        backend: app
+        enabled:
+          - "accesslog"
+          - "requestvalidation"
+          - "responsevalidation"
+          - "timeout"
+          - "lambda"
+        timeout:
+          after: "5s"
+        lambda:
+          arn: "fetchByResourceID"
+          async: false
+          request: >
+            {
+              "resourceid": "#!mapJoin .Request.URL!#",
+              "time": "#!index .Request.Query.time 0!#"
+            }
+          success: '{"status": 200, "bodyPassthrough": true}'
+          error: >
+            {
+              "status":
+              #! if eq .Response.Body.errorType "InvalidInput" !# 400,
+              #! else !#
+              #! if eq .Response.Body.errorType "NotFound" !# 404,
+              #! else !# 500,
+              #! end !#
+              #! end !#
+              "bodyPassthrough": true
+            }
   /ops/pgsql/v1/schema/version/stepUp:
     get:
       summary: "Migrate database schema one version up"

--- a/api.yaml
+++ b/api.yaml
@@ -446,7 +446,7 @@ paths:
           async: false
           request: >
             {
-              "resourceid": "#!mapJoin .Request.URL!#",
+              "resourceid": "#!reduce .Request.URL!#",
               "time": "#!index .Request.Query.time 0!#"
             }
           success: '{"status": 200, "bodyPassthrough": true}'

--- a/api.yaml
+++ b/api.yaml
@@ -416,7 +416,7 @@ paths:
           schema:
             type: "string"
             format: "date-time" # RFC3339Nano format
-      responses:
+      responses: &resource_id_responses
         200:
           description: "List of all assets found with the resource ID at the given time"
           content:
@@ -431,81 +431,7 @@ paths:
                 $ref: "#/components/schemas/Error"
         404:
           description: "The asset is not found"
-      x-transportd:
-        backend: app
-        enabled:
-          - "accesslog"
-          - "requestvalidation"
-          - "responsevalidation"
-          - "timeout"
-          - "lambda"
-        timeout:
-          after: "5s"
-        lambda:
-          arn: "fetchByResourceID"
-          async: false
-          request: >
-            {
-              "resourceid": "#!.Request.URL.resourceid!#",
-              "time": "#!index .Request.Query.time 0!#"
-            }
-          success: '{"status": 200, "bodyPassthrough": true}'
-          error: >
-            {
-              "status":
-              #! if eq .Response.Body.errorType "InvalidInput" !# 400,
-              #! else !#
-              #! if eq .Response.Body.errorType "NotFound" !# 404,
-              #! else !# 500,
-              #! end !#
-              #! end !#
-              "bodyPassthrough": true
-            }
-  /v1/cloud/resourceid/{r1}/{r2}/{r3}:
-    get:
-      summary: "Retrieve a cloud asset at a point in time by resource ID"
-      parameters:
-        - name: "r1"
-          in: "path"
-          description: "The resource id of the asset"
-          required: true
-          schema:
-            type: "string"
-        - name: "r2"
-          in: "path"
-          description: "The resource id of the asset pt 2"
-          required: true
-          schema:
-            type: "string"
-        - name: "r3"
-          in: "path"
-          description: "The resource id of the asset pt 3"
-          required: true
-          schema:
-            type: "string"
-        - name: "time"
-          in: "query"
-          description: "The point in time details for a given asset"
-          required: true
-          schema:
-            type: "string"
-            format: "date-time" # RFC3339Nano format
-      responses:
-        200:
-          description: "List of all assets found with the resource ID at the given time"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CloudAssets"
-        400:
-          description: "Invalid input"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        404:
-          description: "The asset is not found"
-      x-transportd:
+      x-transportd: &resource_id_transportd
         backend: app
         enabled:
           - "accesslog"
@@ -535,6 +461,150 @@ paths:
               #! end !#
               "bodyPassthrough": true
             }
+  /v1/cloud/resourceid/{r1}/{r2}:
+    get:
+      summary: "Retrieve a cloud asset at a point in time by resource ID with support for resource ids containing '/'"
+      parameters:
+        - name: "r1"
+          in: "path"
+          description: "The resource id of the asset"
+          required: true
+          schema:
+            type: "string"
+        - name: "r2"
+          in: "path"
+          description: "The resource id of the asset pt 2"
+          required: true
+          schema:
+            type: "string"
+        - name: "time"
+          in: "query"
+          description: "The point in time details for a given asset"
+          required: true
+          schema:
+            type: "string"
+            format: "date-time" # RFC3339Nano format
+      responses:
+        <<: *resource_id_responses
+      x-transportd:
+        <<: *resource_id_transportd
+  /v1/cloud/resourceid/{r1}/{r2}/{r3}:
+    get:
+      summary: "Retrieve a cloud asset at a point in time by resource ID with support for resource ids containing '/'"
+      parameters:
+        - name: "r1"
+          in: "path"
+          description: "The resource id of the asset"
+          required: true
+          schema:
+            type: "string"
+        - name: "r2"
+          in: "path"
+          description: "The resource id of the asset pt 2"
+          required: true
+          schema:
+            type: "string"
+        - name: "r3"
+          in: "path"
+          description: "The resource id of the asset pt 3"
+          required: true
+          schema:
+            type: "string"
+        - name: "time"
+          in: "query"
+          description: "The point in time details for a given asset"
+          required: true
+          schema:
+            type: "string"
+            format: "date-time" # RFC3339Nano format
+      responses:
+        <<: *resource_id_responses
+      x-transportd:
+        <<: *resource_id_transportd
+  /v1/cloud/resourceid/{r1}/{r2}/{r3}/{r4}:
+    get:
+      summary: "Retrieve a cloud asset at a point in time by resource ID with support for resource ids containing '/'"
+      parameters:
+        - name: "r1"
+          in: "path"
+          description: "The resource id of the asset"
+          required: true
+          schema:
+            type: "string"
+        - name: "r2"
+          in: "path"
+          description: "The resource id of the asset pt 2"
+          required: true
+          schema:
+            type: "string"
+        - name: "r3"
+          in: "path"
+          description: "The resource id of the asset pt 3"
+          required: true
+          schema:
+            type: "string"
+        - name: "r4"
+          in: "path"
+          description: "The resource id of the asset pt 4"
+          required: true
+          schema:
+            type: "string"
+        - name: "time"
+          in: "query"
+          description: "The point in time details for a given asset"
+          required: true
+          schema:
+            type: "string"
+            format: "date-time" # RFC3339Nano format
+      responses:
+        <<: *resource_id_responses
+      x-transportd:
+        <<: *resource_id_transportd
+  /v1/cloud/resourceid/{r1}/{r2}/{r3}/{r4}/{r5}:
+    get:
+      summary: "Retrieve a cloud asset at a point in time by resource ID with support for resource ids containing '/'"
+      parameters:
+        - name: "r1"
+          in: "path"
+          description: "The resource id of the asset"
+          required: true
+          schema:
+            type: "string"
+        - name: "r2"
+          in: "path"
+          description: "The resource id of the asset pt 2"
+          required: true
+          schema:
+            type: "string"
+        - name: "r3"
+          in: "path"
+          description: "The resource id of the asset pt 3"
+          required: true
+          schema:
+            type: "string"
+        - name: "r4"
+          in: "path"
+          description: "The resource id of the asset pt 4"
+          required: true
+          schema:
+            type: "string"
+        - name: "r5"
+          in: "path"
+          description: "The resource id of the asset pt 5"
+          required: true
+          schema:
+            type: "string"
+        - name: "time"
+          in: "query"
+          description: "The point in time details for a given asset"
+          required: true
+          schema:
+            type: "string"
+            format: "date-time" # RFC3339Nano format
+      responses:
+        <<: *resource_id_responses
+      x-transportd:
+        <<: *resource_id_transportd
   /ops/pgsql/v1/schema/version/stepUp:
     get:
       summary: "Migrate database schema one version up"

--- a/gateway.Dockerfile
+++ b/gateway.Dockerfile
@@ -1,3 +1,3 @@
-FROM serverfull-gateway:local
+FROM asecurityteam/serverfull-gateway:v1.0.5
 COPY api.yaml .
 ENV TRANSPORTD_OPENAPI_SPECIFICATION_FILE="api.yaml"

--- a/gateway.Dockerfile
+++ b/gateway.Dockerfile
@@ -1,3 +1,3 @@
-FROM asecurityteam/serverfull-gateway
+FROM serverfull-gateway:local
 COPY api.yaml .
 ENV TRANSPORTD_OPENAPI_SPECIFICATION_FILE="api.yaml"

--- a/integration.Dockerfile
+++ b/integration.Dockerfile
@@ -1,5 +1,14 @@
-FROM openapitools/openapi-generator-cli:v5.0.0-beta AS GENERATOR
+FROM python:3 AS EXPANDER
 COPY api.yaml .
+COPY ./tools/expand-anchors.py .
+RUN chmod 700 expand-anchors.py
+RUN pip install pyyaml
+RUN python ./expand-anchors.py
+
+##################################
+
+FROM openapitools/openapi-generator-cli:v5.0.0-beta AS GENERATOR
+COPY --from=EXPANDER expanded.yaml ./api.yaml
 RUN /usr/local/bin/docker-entrypoint.sh generate \
     -i api.yaml \
     -g go \

--- a/pkg/handlers/v1/cloud_fetch.go
+++ b/pkg/handlers/v1/cloud_fetch.go
@@ -237,6 +237,7 @@ type CloudFetchByResourceIDHandler struct {
 func (h *CloudFetchByResourceIDHandler) Handle(ctx context.Context, input CloudAssetFetchByResourceIDParameters) (CloudAssets, error) {
 	logger := h.LogFn(ctx)
 
+	logger.Info(input.ResourceID)
 	ts, e := time.Parse(time.RFC3339Nano, input.Timestamp)
 	if e != nil {
 		logger.Info(logs.InvalidInput{Reason: e.Error()})

--- a/pkg/handlers/v1/cloud_fetch.go
+++ b/pkg/handlers/v1/cloud_fetch.go
@@ -237,7 +237,6 @@ type CloudFetchByResourceIDHandler struct {
 func (h *CloudFetchByResourceIDHandler) Handle(ctx context.Context, input CloudAssetFetchByResourceIDParameters) (CloudAssets, error) {
 	logger := h.LogFn(ctx)
 
-	logger.Info(input.ResourceID)
 	ts, e := time.Parse(time.RFC3339Nano, input.Timestamp)
 	if e != nil {
 		logger.Info(logs.InvalidInput{Reason: e.Error()})

--- a/tools/expand-anchors.py
+++ b/tools/expand-anchors.py
@@ -1,0 +1,22 @@
+import sys
+import yaml
+
+# A Dumper to derefernce all of our anchors. https://ttl255.com/yaml-anchors-and-aliases-and-how-to-disable-them/
+class NoAliasDumper(yaml.SafeDumper):
+    def ignore_aliases(self, data):
+        return True
+
+yaml_location = "api.yaml"
+ouput_location = "expanded.yaml"
+if (len(sys.argv) > 1):
+    yaml_location = sys.argv[1]
+
+if (len(sys.argv) > 2):
+    ouput_location = sys.argv[2]
+in_yaml = open(yaml_location, "r")
+# Note that the produced YAML has a bug with \n appearing in our lambda templates. These templates should not be
+# consumed by the openapi generator so it doesn't matter, but should be watched out for if we use this for anything else
+out_yaml = open(ouput_location, "w")
+# Loader=yaml.FullLoader is actually the default behavior but it gives you a warning if you aren't explicit
+# default_flow_style keeps everything in block style, the default is JSON grouping
+yaml.dump(yaml.load(in_yaml, Loader=yaml.FullLoader), out_yaml, Dumper=NoAliasDumper, default_flow_style=False)


### PR DESCRIPTION
This uses the new custom template function "reduce" to transform path parameters into a valid resourceId. This is our workaround for swagger interpreting `/` in a path parameter as being part of the path itself.

Currently working on issue where our openapi client generator does not interpret YAML anchors despite them being valid YAML.